### PR TITLE
Add currency fallback for ViewContent

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -671,7 +671,7 @@ function addEcommerceData(eventData, mappedData) {
     if (eventData.transaction_id) mappedData.custom_data.order_id = eventData.transaction_id;
 
 
-    if (mappedData.event_name === 'Purchase') {
+    if (mappedData.event_name === 'Purchase' || mappedData.event_name === 'ViewContent') {
         if (!mappedData.custom_data.currency) {
             mappedData.custom_data.currency = 'USD';
         }


### PR DESCRIPTION
In an ecommerce-context ViewContent also has Items/Products mapped. 
Coming from an GA3/UA Client currency is not a required field for Product Detail - and thus the outgoing hit fails with Facebook API.

Extended the Purchase currency fallback to also include ViewContent. 