### PR TITLE
Adds support for generating fbp

### DIFF
--- a/template.js
+++ b/template.js
@@ -13,6 +13,7 @@ const decodeUriComponent = require('decodeUriComponent');
 const parseUrl = require('parseUrl');
 const computeEffectiveTldPlusOne = require('computeEffectiveTldPlusOne');
 const getRequestHeader = require('getRequestHeader');
+const generateRandom = require('generateRandom');
 
 const containerVersion = getContainerVersion();
 const isDebug = containerVersion.debugMode;
@@ -34,12 +35,13 @@ if (!fbp) fbp = eventData._fbp;
 
 if (url) {
     const urlParsed = parseUrl(url);
+    const subdomainIndex = computeEffectiveTldPlusOne(url).split('.').length - 1;
 
     if (urlParsed && urlParsed.searchParams.fbclid) {
-        const subdomainIndex = computeEffectiveTldPlusOne(url).split('.').length - 1;
-
         fbc = 'fb.' + subdomainIndex + '.' + getTimestampMillis() + '.' + decodeUriComponent(urlParsed.searchParams.fbclid);
     }
+
+    fbp = 'fb.' + subdomainIndex + '.' + getTimestampMillis() + '.' + generateRandom(1000000000, 9999999999);
 }
 
 

--- a/template.js
+++ b/template.js
@@ -41,7 +41,7 @@ if (url) {
         fbc = 'fb.' + subdomainIndex + '.' + getTimestampMillis() + '.' + decodeUriComponent(urlParsed.searchParams.fbclid);
     }
 
-    fbp = 'fb.' + subdomainIndex + '.' + getTimestampMillis() + '.' + generateRandom(1000000000, 9999999999);
+    fbp = fbp || 'fb.' + subdomainIndex + '.' + getTimestampMillis() + '.' + generateRandom(1000000000, 9999999999);
 }
 
 


### PR DESCRIPTION
The `fpb` param is still generated by the JS loaded in by the Facebook pixel. This update generates the `fbp` param to be set as a cookie, but only if it's not already set. This allows (but doesn't require) users to remove the Facebook pixel and Javascript from their websites.