### PR TITLE
Add support for Big Query logging

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
-    "singleQuote": true,
-    "trailingComma": "none"
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ You can use this tag for the Google Tag Manager Server Side container to set up 
 It works based on Universal Analytics or Google Analytics 4 requests inside the Google Tag Manager Server Side container.
 Also, it supports custom [Data client](https://github.com/stape-io/data-client) that allows retrieving Data Layer from web containers easier.
 
-Facebook Conversion API (previously Facebook server-side tracking) has the same purpose as Facebook pixel - it tracks what users are doing on your site. 
+Facebook Conversion API (previously Facebook server-side tracking) has the same purpose as Facebook pixel - it tracks what users are doing on your site.
 But the difference between web and server tracking is that pixel requests are processed in the user’s browser, while Facebook conversion API works through the cloud server.
 
 ## How to use Facebook tag
@@ -17,4 +17,4 @@ But the difference between web and server tracking is that pixel requests are pr
 
 ## Open Source
 
-Facebook Tag for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+The **Facebook Tag for GTM Server Side** is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: 96b0d62caef253838e47f969171ed03fae8c9ee0
+    changeNotes: Add support for Big Query logging.
   - sha: a0438d00ee0de8b38b899b83d16cda7899a5f64c
     changeNotes: Fixed referrer_url mapping place.
   - sha: 98500beca256aaaff968ea21f552546f4e7be5af

--- a/template.tpl
+++ b/template.tpl
@@ -756,9 +756,11 @@ const fromBase64 = require('fromBase64');
 const createRegex = require('createRegex');
 const testRegex = require('testRegex');
 const Promise = require('Promise');
+const BigQuery = require('BigQuery');
 
-const isLoggingEnabled = determinateIsLoggingEnabled();
-const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
+/**********************************************************************************************/
+
+const traceId = getRequestHeader('trace-id');
 
 const eventData = getAllEventData();
 
@@ -767,10 +769,6 @@ if (!isConsentGivenOrNotRequired()) {
 }
 
 const url = eventData.page_location || getRequestHeader('referer');
-const subDomainIndex = url
-  ? computeEffectiveTldPlusOne(url).split('.').length - 1
-  : 1;
-
 if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
   return data.gtmOnSuccess();
 }
@@ -782,6 +780,10 @@ let fbp = getCookieValues('_fbp')[0] || commonCookie._fbp;
 
 if (!fbc) fbc = eventData._fbc;
 if (!fbp) fbp = eventData._fbp;
+
+const subDomainIndex = url
+  ? computeEffectiveTldPlusOne(url).split('.').length - 1
+  : 1;
 
 if (url) {
   const urlParsed = parseUrl(url);
@@ -869,19 +871,17 @@ const requests = pixelIdsAndAccessTokens.map((pixelIdAndAccessTokenObj) => {
     enc(pixelId) +
     '/events?access_token=' +
     enc(accessToken);
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Facebook',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: mappedEventData.event_name,
-        RequestMethod: 'POST',
-        RequestUrl: postUrl,
-        RequestBody: postBody
-      })
-    );
-  }
+
+  log({
+    Name: 'Facebook',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: mappedEventData.event_name,
+    RequestMethod: 'POST',
+    RequestUrl: postUrl,
+    RequestBody: postBody
+  });
+
   return sendHttpRequest(
     postUrl,
     { headers: { 'content-type': 'application/json' }, method: 'POST' },
@@ -893,19 +893,15 @@ Promise.all(requests).then((results) => {
   let someRequestFailed = false;
 
   results.forEach((result) => {
-    if (isLoggingEnabled) {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Facebook',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: mappedEventData.event_name,
-          ResponseStatusCode: result.statusCode,
-          ResponseHeaders: result.headers,
-          ResponseBody: result.body
-        })
-      );
-    }
+    log({
+      Name: 'Facebook',
+      Type: 'Response',
+      TraceId: traceId,
+      EventName: mappedEventData.event_name,
+      ResponseStatusCode: result.statusCode,
+      ResponseHeaders: result.headers,
+      ResponseBody: result.body
+    });
 
     if (result.statusCode < 200 || result.statusCode >= 300) {
       someRequestFailed = true;
@@ -925,11 +921,14 @@ if (data.useOptimisticScenario) {
   data.gtmOnSuccess();
 }
 
+/**********************************************************************************************/
+// Vendor related functions
+
 function getEventName(data) {
   if (data.inheritEventName === 'inherit') {
-    let eventName = eventData.event_name;
+    const eventName = eventData.event_name;
 
-    let gaToFacebookEventName = {
+    const gaToFacebookEventName = {
       page_view: 'PageView',
       'gtm.dom': 'PageView',
       add_payment_info: 'AddPaymentInfo',
@@ -971,7 +970,7 @@ function getEventName(data) {
 }
 
 function mapEvent(eventData, data) {
-  let eventName = getEventName(data);
+  const eventName = getEventName(data);
 
   let mappedData = {
     event_name: eventName,
@@ -1015,19 +1014,6 @@ function mapEvent(eventData, data) {
   mappedData = hashDataIfNeeded(mappedData);
 
   return mappedData;
-}
-
-function enc(data) {
-  data = data || '';
-  return encodeUriComponent(data);
-}
-
-function isHashed(value) {
-  if (!value) {
-    return false;
-  }
-
-  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
 }
 
 function hashData(key, value) {
@@ -1111,7 +1097,7 @@ function overrideDataIfNeeded(mappedData) {
 
 function cleanupData(mappedData) {
   if (mappedData.user_data) {
-    let userData = {};
+    const userData = {};
 
     for (let userDataKey in mappedData.user_data) {
       if (isValidValue(mappedData.user_data[userDataKey])) {
@@ -1123,7 +1109,7 @@ function cleanupData(mappedData) {
   }
 
   if (mappedData.custom_data) {
-    let customData = {};
+    const customData = {};
 
     for (let customDataKey in mappedData.custom_data) {
       if (isValidValue(mappedData.custom_data[customDataKey])) {
@@ -1138,7 +1124,7 @@ function cleanupData(mappedData) {
   }
 
   if (mappedData.app_data) {
-    let appData = {};
+    const appData = {};
 
     for (let appDataKey in mappedData.app_data) {
       if (isValidValue(mappedData.app_data[appDataKey])) {
@@ -1150,11 +1136,6 @@ function cleanupData(mappedData) {
   }
 
   return mappedData;
-}
-
-function isValidValue(value) {
-  const valueType = getType(value);
-  return valueType !== 'null' && valueType !== 'undefined' && value !== '';
 }
 
 function addEcommerceData(eventData, mappedData) {
@@ -1183,7 +1164,7 @@ function addEcommerceData(eventData, mappedData) {
 
     const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
     eventData.items.forEach((d, i) => {
-      let content = {};
+      const content = {};
       if (d[itemIdKey]) content.id = d[itemIdKey];
       if (d.item_name) content.title = d.item_name;
       if (d.item_brand) content.brand = d.item_brand;
@@ -1310,7 +1291,7 @@ function addUserData(eventData, mappedData) {
 }
 
 function addServerEventData(eventData, mappedData) {
-  let serverEventDataList = {};
+  const serverEventDataList = {};
 
   if (eventData.event_id) mappedData.event_id = eventData.event_id;
   else if (eventData.transaction_id)
@@ -1384,7 +1365,7 @@ function addAppData(eventData, mappedData) {
 }
 
 function setGtmEecCookie(userData) {
-  let gtmeecCookie = {};
+  const gtmeecCookie = {};
 
   if (userData.em) gtmeecCookie.em = userData.em;
   if (userData.ph) gtmeecCookie.ph = userData.ph;
@@ -1448,6 +1429,24 @@ function enhanceEventData(userData) {
   return userData;
 }
 
+/**********************************************************************************************/
+// Helpers
+
+function enc(data) {
+  data = data || '';
+  return encodeUriComponent(data);
+}
+
+function isHashed(value) {
+  if (!value) return false;
+  return makeString(value).match('^[A-Fa-f0-9]{64}$') !== null;
+}
+
+function isValidValue(value) {
+  const valueType = getType(value);
+  return valueType !== 'null' && valueType !== 'undefined' && value !== '';
+}
+
 function normalizePhoneNumber(phoneNumber) {
   if (!phoneNumber) return phoneNumber;
   const itemRegex = createRegex('^[0-9]$');
@@ -1462,6 +1461,79 @@ function isConsentGivenOrNotRequired() {
   if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
   const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
   return xGaGcs[2] === '1';
+}
+
+function log(rawDataToLog) {
+  const logDestinationsHandlers = {};
+  if (determinateIsLoggingEnabled())
+    logDestinationsHandlers.console = logConsole;
+  if (determinateIsLoggingEnabledForBigQuery())
+    logDestinationsHandlers.bigQuery = logToBigQuery;
+
+  // Key mappings for each log destination
+  const keyMappings = {
+    // No transformation for Console is needed.
+    bigQuery: {
+      Name: 'tag_name',
+      Type: 'type',
+      TraceId: 'trace_id',
+      EventName: 'event_name',
+      RequestMethod: 'request_method',
+      RequestUrl: 'request_url',
+      RequestBody: 'request_body',
+      ResponseStatusCode: 'response_status_code',
+      ResponseHeaders: 'response_headers',
+      ResponseBody: 'response_body'
+    }
+  };
+
+  for (const logDestination in logDestinationsHandlers) {
+    const handler = logDestinationsHandlers[logDestination];
+    if (!handler) continue;
+
+    const mapping = keyMappings[logDestination];
+    const dataToLog = mapping ? {} : rawDataToLog;
+    // Map keys based on the log destination
+    if (mapping) {
+      for (const key in rawDataToLog) {
+        const mappedKey = mapping[key] || key; // Fallback to original key if no mapping exists
+        dataToLog[mappedKey] = rawDataToLog[key];
+      }
+    }
+
+    handler(dataToLog);
+  }
+}
+
+function logConsole(dataToLog) {
+  logToConsole(JSON.stringify(dataToLog));
+}
+
+function logToBigQuery(dataToLog) {
+  const connectionInfo = {
+    projectId: data.logBigQueryProjectId,
+    datasetId: data.logBigQueryDatasetId,
+    tableId: data.logBigQueryTableId
+  };
+
+  // timestamp is required.
+  dataToLog.timestamp = getTimestampMillis();
+
+  // Columns with type JSON need to be stringified.
+  ['request_body', 'response_headers', 'response_body'].forEach((p) => {
+    const value = dataToLog[p];
+    // These types don't need to be stringified.
+    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1)
+      dataToLog[p] = JSON.stringify(value);
+  });
+
+  // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.
+  // Ref: https://gtm-gear.com/posts/gtm-templates-testing/
+  const bigquery =
+    getType(BigQuery) === 'function'
+      ? BigQuery() /* Only during Unit Tests */
+      : BigQuery;
+  bigquery.insert(connectionInfo, [dataToLog], { ignoreUnknownValues: true });
 }
 
 function determinateIsLoggingEnabled() {
@@ -1484,6 +1556,11 @@ function determinateIsLoggingEnabled() {
   }
 
   return data.logType === 'always';
+}
+
+function determinateIsLoggingEnabledForBigQuery() {
+  if (data.bigQueryLogType === 'no') return false;
+  return data.bigQueryLogType === 'always';
 }
 
 
@@ -1858,6 +1935,67 @@ ___SERVER_PERMISSIONS___
       "isEditedByUser": true
     },
     "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "access_bigquery",
+        "versionId": "1"
+      },
+      "param": [
+        {
+          "key": "allowedTables",
+          "value": {
+            "type": 2,
+            "listItem": [
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "projectId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "datasetId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "tableId"
+                  },
+                  {
+                    "type": 1,
+                    "string": "operation"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "*"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "clientAnnotations": {
+      "isEditedByUser": true
+    },
+    "isRequired": true
   }
 ]
 
@@ -1866,19 +2004,83 @@ ___TESTS___
 
 scenarios:
 - name: Check semantical errors
-  code: |-
-    const mockData = {
-      pixelId: 12345,
-      accessToken: 'test'
-    };
+  code: runCode(mockData);
+- name: Should log to console, if the 'Always log to console' option is selected
+  code: "mockData.logType = 'always';\n\nconst expectedDebugMode = true;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nmock('logToConsole',\
+    \ (logData) => {\n  const parsedLogData = JSON.parse(logData);\n  requiredConsoleKeys.forEach(p\
+    \ => assertThat(parsedLogData[p]).isDefined());\n});\n\nrunCode(mockData);\n\n\
+    assertApi('logToConsole').wasCalled();\n"
+- name: Should log to console, if the 'Log during debug and preview' option is selected
+    AND is on preview mode
+  code: |
+    mockData.logType = 'debug';
 
+    const expectedDebugMode = true;
+    mock('getContainerVersion', () => {
+      return {
+        debugMode: expectedDebugMode
+      };
+    });
+
+    mock('logToConsole', (logData) => {
+      const parsedLogData = JSON.parse(logData);
+      requiredConsoleKeys.forEach(p => assertThat(parsedLogData[p]).isDefined());
+    });
 
     runCode(mockData);
-setup: ''
+
+    assertApi('logToConsole').wasCalled();
+- name: Should NOT log to console, if the 'Log during debug and preview' option is
+    selected AND is NOT on preview mode
+  code: "mockData.logType = 'debug';\n\nconst expectedDebugMode = false;\nmock('getContainerVersion',\
+    \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nrunCode(mockData);\n\
+    \nassertApi('logToConsole').wasNotCalled();\n"
+- name: Should NOT log to console, if the 'Do not log' option is selected
+  code: |
+    mockData.logType = 'no';
+
+    runCode(mockData);
+
+    assertApi('logToConsole').wasNotCalled();
+- name: Should log to BQ, if the 'Log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'always';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ assertThat(connectionInfo).isDefined();\n      assertThat(rows).isArray();\n\
+    \      assertThat(rows).hasLength(1);\n      requiredBqKeys.forEach(p => assertThat(rows[0][p]).isDefined());\n\
+    \      assertThat(options).isEqualTo(expectedBqOptions);\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
+- name: Should NOT log to BQ, if the 'Do not log to BigQuery' option is selected
+  code: "mockData.bigQueryLogType = 'no';\n\n// assertApi doesn't work for 'BigQuery.insert()'.\n\
+    // Ref: https://gtm-gear.com/posts/gtm-templates-testing/\nmock('BigQuery', ()\
+    \ => {\n  return { \n    insert: (connectionInfo, rows, options) => { \n     \
+    \ fail('BigQuery.insert should not have been called.');\n      return Promise.create((resolve,\
+    \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
+setup: |-
+  const setCookie = require('setCookie');
+  const JSON = require('JSON');
+  const Promise = require('Promise');
+
+  const requiredConsoleKeys = ['Type', 'TraceId', 'Name'];
+  const requiredBqKeys = ['timestamp', 'type', 'trace_id', 'tag_name'];
+
+  const expectedValue = 'test';
+  const expectedBqOptions = { ignoreUnknownValues: true };
+  const expectedPixelId = '1111111111111';
+
+  const mockData = {
+    pixelId: expectedPixelId,
+    accessToken: expectedValue,
+    eventType: 'custom',
+    eventName: expectedValue,
+    logBigQueryProjectId: expectedValue,
+    logBigQueryDatasetId: expectedValue,
+    logBigQueryTableId: expectedValue,
+  };
 
 
 ___NOTES___
 
 Created on 10/11/2020, 18:14:02
-
 


### PR DESCRIPTION
Hi.

- Added support for BigQuery logging for the [GTMS-7](https://github.com/stape-io/gtm-standards/blob/main/standards/GTMS-7.md).
  - Now, the tag has only one entry point for logging, the `log` function. It receives the data in the format used by the `logToConsole` logs, and decides where to route the data to (only Console, only BigQuery, or both), based on the options the end-user chose in the template UI. It also transforms the data into the required BQ format.
- Added tests for both types of logs (Console and BigQuery).
- Updated the README.