### PR TITLE
Big Query log improvement

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: 'https://stape.io/'
 versions:
-  - sha: 0227a784f48c3154036cc22524722969655b7c8a
+  - sha: 58e2198a5eda667bfd1753e04f3b1f6c820f9415
     changeNotes: Improve JSON handling for BQ logging.
   - sha: 96b0d62caef253838e47f969171ed03fae8c9ee0
     changeNotes: Add support for Big Query logging.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: 0227a784f48c3154036cc22524722969655b7c8a
+    changeNotes: Improve JSON handling for BQ logging.
   - sha: 96b0d62caef253838e47f969171ed03fae8c9ee0
     changeNotes: Add support for Big Query logging.
   - sha: a0438d00ee0de8b38b899b83d16cda7899a5f64c

--- a/template.js
+++ b/template.js
@@ -787,16 +787,8 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
-    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
-    // to convert them back into their original format in BigQuery.
-    // Although it does return undefined and permits the code to continue running,
-    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
-    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
-
-    // If someday this is fixed, the lines below can be changed to this one:
-    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
-
+    // GTM Sandboxed JSON.parse returns undefined for malformed JSON but throws post-execution, causing execution failure.
+    // If fixed, could use: dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
     dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 

--- a/template.js
+++ b/template.js
@@ -787,10 +787,17 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    const value = dataToLog[p];
-    // These types don't need to be stringified.
-    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1)
-      dataToLog[p] = JSON.stringify(value);
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 
   // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.

--- a/template.tpl
+++ b/template.tpl
@@ -1588,16 +1588,8 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
-    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
-    // to convert them back into their original format in BigQuery.
-    // Although it does return undefined and permits the code to continue running,
-    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
-    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
-
-    // If someday this is fixed, the lines below can be changed to this one:
-    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
-
+    // GTM Sandboxed JSON.parse returns undefined for malformed JSON but throws post-execution, causing execution failure.
+    // If fixed, could use: dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
     dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 

--- a/template.tpl
+++ b/template.tpl
@@ -726,6 +726,73 @@ ___TEMPLATE_PARAMETERS___
         "defaultValue": "debug"
       }
     ]
+  },
+  {
+    "displayName": "BigQuery Logs Settings",
+    "name": "bigQueryLogsGroup",
+    "groupStyle": "ZIPPY_CLOSED",
+    "type": "GROUP",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "bigQueryLogType",
+        "radioItems": [
+          {
+            "value": "no",
+            "displayValue": "Do not log to BigQuery"
+          },
+          {
+            "value": "always",
+            "displayValue": "Log to BigQuery"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "no"
+      },
+      {
+        "type": "GROUP",
+        "name": "logsBigQueryConfigGroup",
+        "groupStyle": "NO_ZIPPY",
+        "subParams": [
+          {
+            "type": "TEXT",
+            "name": "logBigQueryProjectId",
+            "displayName": "BigQuery Project ID",
+            "simpleValueType": true,
+            "help": "Optional.  \u003cbr\u003e\u003cbr\u003e  If omitted, it will be retrieved from the environment variable \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e where the server container is running. If the server container is running on Google Cloud, \u003cI\u003eGOOGLE_CLOUD_PROJECT\u003c/i\u003e will already be set to the Google Cloud project\u0027s ID."
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryDatasetId",
+            "displayName": "BigQuery Dataset ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          },
+          {
+            "type": "TEXT",
+            "name": "logBigQueryTableId",
+            "displayName": "BigQuery Table ID",
+            "simpleValueType": true,
+            "valueValidators": [
+              {
+                "type": "NON_EMPTY"
+              }
+            ]
+          }
+        ],
+        "enablingConditions": [
+          {
+            "paramName": "bigQueryLogType",
+            "paramValue": "always",
+            "type": "EQUALS"
+          }
+        ]
+      }
+    ]
   }
 ]
 
@@ -1521,10 +1588,17 @@ function logToBigQuery(dataToLog) {
 
   // Columns with type JSON need to be stringified.
   ['request_body', 'response_headers', 'response_body'].forEach((p) => {
-    const value = dataToLog[p];
-    // These types don't need to be stringified.
-    if (['string', 'null', 'undefined'].indexOf(getType(value)) === -1)
-      dataToLog[p] = JSON.stringify(value);
+    // The JSON.parse of GTM Sandboxed JS should not throw and should return undefined if parsing
+    // a malformed JSON. This would be great to parse stringified objects and arrays, so that it's not needed
+    // to convert them back into their original format in BigQuery.
+    // Although it does return undefined and permits the code to continue running,
+    // it throws an error after the execution is complete, making tests and the overall execution to show as failed.
+    // Ref: https://developers.google.com/tag-platform/tag-manager/server-side/api#json
+
+    // If someday this is fixed, the lines below can be changed to this one:
+    // dataToLog[p] = JSON.stringify(JSON.parse(dataToLog[p]) || dataToLog[p]);
+
+    dataToLog[p] = JSON.stringify(dataToLog[p]);
   });
 
   // assertApi doesn't work for 'BigQuery.insert()'. It's needed to convert BigQuery into a function when testing.
@@ -2058,7 +2132,6 @@ scenarios:
     \ fail('BigQuery.insert should not have been called.');\n      return Promise.create((resolve,\
     \ reject) => {\n        resolve();\n      });\n    }\n  };\n});\n\nrunCode(mockData);"
 setup: |-
-  const setCookie = require('setCookie');
   const JSON = require('JSON');
   const Promise = require('Promise');
 


### PR DESCRIPTION
Hi.

When testing, I noticed that some APIs don't return a valid string or value to insert into the BQ table.
Thus, it's required that they be passed into the `JSON.stringify` first.

I also noticed that I had forgotten to add the buttons to the UI. Fixed this now.