### PR TITLE
Update template.js with new externalDomain field

### DIFF
--- a/template.js
+++ b/template.js
@@ -89,9 +89,11 @@ const postBody = {
     'stape-gtmss-2.1.1' + (data.enableEventEnhancement ? '-ee' : '')
 };
 
+const domain = data.externalDomain ? data.externalDomain : 'auto';
+
 if (data.enableEventEnhancement) {
   mappedEventData.user_data = enhanceEventData(mappedEventData.user_data);
-  setGtmEecCookie(mappedEventData.user_data);
+  setGtmEecCookie(mappedEventData.user_data, domain);
 }
 
 if (eventData.test_event_code || data.testId) {
@@ -101,7 +103,7 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: 'auto',
+  domain: domain,
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -630,7 +632,7 @@ function addAppData(eventData, mappedData) {
   return mappedData;
 }
 
-function setGtmEecCookie(userData) {
+function setGtmEecCookie(userData, domain) {
   const gtmeecCookie = {};
 
   if (userData.em) gtmeecCookie.em = userData.em;
@@ -647,7 +649,7 @@ function setGtmEecCookie(userData) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: 'auto',
+    domain: domain,
     path: '/',
     samesite: 'strict',
     secure: true,


### PR DESCRIPTION
Hey, we have a scenario when sGTM is accessible from outside world by different domain than it is within private network. Because of that having a domain set to `auto` results with problems when cookies are not set up correctly:
![image](https://github.com/user-attachments/assets/08b146c0-74a4-4a78-a32c-63de8a2cce6b)

In that PR I am suggesting a change that solve that problem, by first adding new field in config:
![image](https://github.com/user-attachments/assets/6eb28245-9b9a-44de-91e8-34c8854e0a99)

And then based on that field select domain in cookie config:
```
const domain = data.externalDomain ? data.externalDomain : 'auto';
```

Please let me know if you can make such changes, as we would like to not forking tag template, but still use your implementation.