### PR TITLE
Add cookie domain override option

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
   - sha: 3ba29eb2b74b367cc5b9d26366d33a4804ff2dac
-    changeNotes: Update to API v22. Prevent HTTP requests from triggering when running unit tests.
+    changeNotes: Add cookie domain override field.
   - sha: 98f6ecd0c8114eabbb294d079c1b3e0b8f8aadcd
     changeNotes: Update to API v22. Prevent HTTP requests from triggering when running unit tests.
   - sha: 58e2198a5eda667bfd1753e04f3b1f6c820f9415

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: 'https://stape.io/'
 versions:
-  - sha: 3ba29eb2b74b367cc5b9d26366d33a4804ff2dac
+  - sha: 05b7a1d3f0aef3bb1cf33799fe9cb98d55eee712
     changeNotes: Add cookie domain override field.
   - sha: 98f6ecd0c8114eabbb294d079c1b3e0b8f8aadcd
     changeNotes: Update to API v22. Prevent HTTP requests from triggering when running unit tests.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: 3ba29eb2b74b367cc5b9d26366d33a4804ff2dac
+    changeNotes: Update to API v22. Prevent HTTP requests from triggering when running unit tests.
   - sha: 98f6ecd0c8114eabbb294d079c1b3e0b8f8aadcd
     changeNotes: Update to API v22. Prevent HTTP requests from triggering when running unit tests.
   - sha: 58e2198a5eda667bfd1753e04f3b1f6c820f9415

--- a/template.js
+++ b/template.js
@@ -89,9 +89,11 @@ const postBody = {
     'stape-gtmss-2.1.1' + (data.enableEventEnhancement ? '-ee' : '')
 };
 
+const domain = data.externalDomain ? data.externalDomain : 'auto';
+
 if (data.enableEventEnhancement) {
   mappedEventData.user_data = enhanceEventData(mappedEventData.user_data);
-  setGtmEecCookie(mappedEventData.user_data);
+  setGtmEecCookie(mappedEventData.user_data, domain);
 }
 
 if (eventData.test_event_code || data.testId) {
@@ -101,7 +103,7 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: 'auto',
+  domain: domain,
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -630,7 +632,7 @@ function addAppData(eventData, mappedData) {
   return mappedData;
 }
 
-function setGtmEecCookie(userData) {
+function setGtmEecCookie(userData, domain) {
   const gtmeecCookie = {};
 
   if (userData.em) gtmeecCookie.em = userData.em;
@@ -647,7 +649,7 @@ function setGtmEecCookie(userData) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: 'auto',
+    domain: domain,
     path: '/',
     samesite: 'strict',
     secure: true,

--- a/template.js
+++ b/template.js
@@ -101,7 +101,9 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
+  domain: isUIFieldTrue(data.overrideCookieDomain)
+    ? data.overridenCookieDomain
+    : 'auto',
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -647,7 +649,9 @@ function setGtmEecCookie(userData) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
+    domain: isUIFieldTrue(data.overrideCookieDomain)
+      ? data.overridenCookieDomain
+      : 'auto',
     path: '/',
     samesite: 'strict',
     secure: true,
@@ -719,6 +723,10 @@ function normalizePhoneNumber(phoneNumber) {
     .split('')
     .filter((item) => testRegex(itemRegex, item))
     .join('');
+}
+
+function isUIFieldTrue(field) {
+  return [true, 'true'].indexOf(field) !== -1;
 }
 
 function isConsentGivenOrNotRequired() {

--- a/template.js
+++ b/template.js
@@ -89,11 +89,9 @@ const postBody = {
     'stape-gtmss-2.1.1' + (data.enableEventEnhancement ? '-ee' : '')
 };
 
-const domain = data.externalDomain ? data.externalDomain : 'auto';
-
 if (data.enableEventEnhancement) {
   mappedEventData.user_data = enhanceEventData(mappedEventData.user_data);
-  setGtmEecCookie(mappedEventData.user_data, domain);
+  setGtmEecCookie(mappedEventData.user_data);
 }
 
 if (eventData.test_event_code || data.testId) {
@@ -103,7 +101,7 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: domain,
+  domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -632,7 +630,7 @@ function addAppData(eventData, mappedData) {
   return mappedData;
 }
 
-function setGtmEecCookie(userData, domain) {
+function setGtmEecCookie(userData) {
   const gtmeecCookie = {};
 
   if (userData.em) gtmeecCookie.em = userData.em;
@@ -649,7 +647,7 @@ function setGtmEecCookie(userData, domain) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: domain,
+    domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
     path: '/',
     samesite: 'strict',
     secure: true,

--- a/template.tpl
+++ b/template.tpl
@@ -941,7 +941,9 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
+  domain: isUIFieldTrue(data.overrideCookieDomain)
+    ? data.overridenCookieDomain
+    : 'auto',
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -1487,7 +1489,9 @@ function setGtmEecCookie(userData) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
+    domain: isUIFieldTrue(data.overrideCookieDomain)
+      ? data.overridenCookieDomain
+      : 'auto',
     path: '/',
     samesite: 'strict',
     secure: true,
@@ -1559,6 +1563,10 @@ function normalizePhoneNumber(phoneNumber) {
     .split('')
     .filter((item) => testRegex(itemRegex, item))
     .join('');
+}
+
+function isUIFieldTrue(field) {
+  return [true, 'true'].indexOf(field) !== -1;
 }
 
 function isConsentGivenOrNotRequired() {

--- a/template.tpl
+++ b/template.tpl
@@ -331,6 +331,45 @@ ___TEMPLATE_PARAMETERS___
     "canBeEmptyString": true
   },
   {
+    "type": "SELECT",
+    "name": "overrideCookieDomain",
+    "displayName": "Override the cookie domain",
+    "macrosInSelect": true,
+    "selectItems": [
+      {
+        "value": false,
+        "displayValue": "False"
+      },
+      {
+        "value": true,
+        "displayValue": "True"
+      }
+    ],
+    "simpleValueType": true,
+    "subParams": [
+      {
+        "type": "TEXT",
+        "name": "overridenCookieDomain",
+        "displayName": "Cookie Domain",
+        "simpleValueType": true,
+        "enablingConditions": [
+          {
+            "paramName": "overrideCookieDomain",
+            "paramValue": false,
+            "type": "NOT_EQUALS"
+          }
+        ],
+        "help": "Enable this option to override the cookie domain.\u003cbr\u003eEnter your website\u0027s top-level domain as a fixed value (e.g., example.com). \u003cbr\u003e If left as \"auto\", the top-level domain will be automatically determined using the following priority: \u003cul\u003e \u003cli\u003eTop-level domain of the \u003ci\u003eForwarded\u003c/i\u003e header (if present).\u003c/li\u003e \u003cli\u003eTop-level domain of the \u003ci\u003eX-Forwarded-Host\u003c/i\u003e header (if present).\u003c/li\u003e \u003cli\u003eTop-level domain of the \u003ci\u003eHost\u003c/i\u003e header.\u003c/li\u003e \u003c/ul\u003e",
+        "valueValidators": [
+          {
+            "type": "NON_EMPTY"
+          }
+        ]
+      }
+    ],
+    "defaultValue": false
+  },
+  {
     "type": "CHECKBOX",
     "name": "generateFbp",
     "checkboxText": "Generate _fbp cookie if it not exist",
@@ -902,7 +941,7 @@ if (eventData.test_event_code || data.testId) {
 }
 
 const cookieOptions = {
-  domain: 'auto',
+  domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
   path: '/',
   samesite: 'Lax',
   secure: true,
@@ -1448,7 +1487,7 @@ function setGtmEecCookie(userData) {
   if (userData.fb_login_id) gtmeecCookie.fb_login_id = userData.fb_login_id;
 
   setCookie('_gtmeec', toBase64(JSON.stringify(gtmeecCookie)), {
-    domain: 'auto',
+    domain: data.overrideCookieDomain ? data.overridenCookieDomain : 'auto',
     path: '/',
     samesite: 'strict',
     secure: true,
@@ -2073,6 +2112,30 @@ scenarios:
     \  return {\n    then: (callback) => { \n      callback({ statusCode: 200 });\n\
     \      return {\n        then: () => {},\n        catch: () => {}\n      };\n\
     \    },\n    catch: (callback) => callback()\n  };\n});\n\nrunCode(mockData);"
+- name: Cookie domain is NOT overriden when option is NOT selected
+  code: "mockData.overrideCookieDomain = false;\nmockData.enableEventEnhancement =\
+    \ true;\n\nconst expectedFbp = 'expectedFbp';\nconst expectedFbc = 'expectedFbc';\n\
+    mock('getAllEventData', {\n  _fbp: expectedFbp,\n  _fbc: expectedFbc\n});\n\n\
+    mock('setCookie', (cookieName, cookieValue, cookieOptions, noEncode) => {\n  switch\
+    \ (cookieName) {\n    case '_fbp':\n    case '_fbc':\n    case '_gtmeec':\n  \
+    \    if (cookieOptions.domain !== 'auto') fail('cookieDomain shouldn\\'t have\
+    \ been overriden');\n      break;\n  }\n});\n\nmock('sendHttpRequest', (requestUrl,\
+    \ requestOptions, requestBody) => {\n  return {\n    then: (callback) => { \n\
+    \      callback({ statusCode: 200 });\n      return {\n        then: () => {},\n\
+    \        catch: () => {}\n      };\n    },\n    catch: (callback) => callback()\n\
+    \  };\n});\n\nrunCode(mockData);"
+- name: Cookie domain is overriden when option is selected
+  code: "mockData.overrideCookieDomain = true;\nmockData.overridenCookieDomain = 'example.com';\n\
+    mockData.enableEventEnhancement = true;\n\nconst expectedFbp = 'expectedFbp';\n\
+    const expectedFbc = 'expectedFbc';\nmock('getAllEventData', {\n  _fbp: expectedFbp,\n\
+    \  _fbc: expectedFbc\n});\n\nmock('setCookie', (cookieName, cookieValue, cookieOptions,\
+    \ noEncode) => {\n  switch (cookieName) {\n    case '_fbp':\n    case '_fbc':\n\
+    \    case '_gtmeec':\n      assertThat(cookieOptions.domain).isEqualTo(mockData.overridenCookieDomain);\n\
+    \      break;\n  }\n});\n\nmock('sendHttpRequest', (requestUrl, requestOptions,\
+    \ requestBody) => {\n  return {\n    then: (callback) => { \n      callback({\
+    \ statusCode: 200 });\n      return {\n        then: () => {},\n        catch:\
+    \ () => {}\n      };\n    },\n    catch: (callback) => callback()\n  };\n});\n\
+    \nrunCode(mockData);"
 - name: Should log to console, if the 'Always log to console' option is selected
   code: "mockData.logType = 'always';\n\nconst expectedDebugMode = true;\nmock('getContainerVersion',\
     \ () => {\n  return {\n    debugMode: expectedDebugMode\n  };\n}); \n\nmock('logToConsole',\


### PR DESCRIPTION
Hi.

As mentioned in https://github.com/stape-io/facebook-tag/pull/66 the cookie domain option is being added in this PR.
