### PR TITLE
Upgrade ads api to v23.0

### DIFF
--- a/template.js
+++ b/template.js
@@ -116,7 +116,7 @@ if (eventData.test_event_code || data.testId) {
     : data.testId;
 }
 
-const apiVersion = '22.0';
+const apiVersion = '23.0';
 let pixelIdsAndAccessTokens = [
   { pixelId: data.pixelId, accessToken: data.accessToken }
 ];


### PR DESCRIPTION
Version v22.0 has now been deprecated
![WhatsApp Image 2025-06-16 at 19 17 38](https://github.com/user-attachments/assets/e706fdc3-92a4-4274-aaee-041bd16e9454)
