### PR TITLE
Add App Secret Proof support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server-gtm-sandboxed-apis.d.ts

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/facebook-tag'
 versions:
-  - sha: 7982655169e4d52c1f20069653618fe721e1c6cc
+  - sha: 8093c373ed116395251221f85e50c5e71f830b16
     changeNotes: Added for App Secret Proof to the API request.
   - sha: 989debed2cd1816a512f8c36b174a0afd67fbbd8
     changeNotes: Added hints to UI parameters sections.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/facebook-tag'
 versions:
+  - sha: 7982655169e4d52c1f20069653618fe721e1c6cc
+    changeNotes: Added for App Secret Proof to the API request.
   - sha: 989debed2cd1816a512f8c36b174a0afd67fbbd8
     changeNotes: Added hints to UI parameters sections.
   - sha: bfb2894d2cd3b38f468b761909025bbda9e2d6c7

--- a/template.js
+++ b/template.js
@@ -121,7 +121,7 @@ let pixelsConfig = [
   {
     pixelId: data.pixelId,
     accessToken: data.accessToken,
-    appSecretProof: data.appSecretProof
+    appSecretProof: data.useAppSecretProof ? data.appSecretProof : undefined
   }
 ];
 if (data.enableMultipixelSetup) {


### PR DESCRIPTION
- Added support to the App Secret Proof parameter: [[1]](https://github.com/stape-io/facebook-tag/pull/78/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R120-R143), [[2]](https://github.com/stape-io/facebook-tag/pull/78/files#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R266-R322)
- Added a `.catch()` clause to the `Promise.all()` block to catch problems with requests that timeout or are rejected: [[1]](https://github.com/stape-io/facebook-tag/pull/78/files#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R162-R198)