### PR TITLE
Add phone mapping for user_data

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1577,6 +1577,8 @@ function addUserData(eventData, mappedData) {
   if (eventData.phone) mappedData.user_data.ph = eventData.phone;
   else if (user_data.phone_number)
     mappedData.user_data.ph = user_data.phone_number;
+  else if (user_data.phone)
+    mappedData.user_data.ph = user_data.phone;
 
   if (eventData.city) mappedData.user_data.ct = eventData.city;
   else if (address.city) mappedData.user_data.ct = address.city;


### PR DESCRIPTION
Shopify Stape app uses user_data.phone field, 
not user_data.phone_number