### PR TITLE
Add option to select parameter for automapping item data

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: 'https://stape.io/'
 documentation: 'https://github.com/stape-io/facebook-tag'
 versions:
+  - sha: f7a34753bc6092e8a032de564cae18280138b428
+    changeNotes: Added an option to choose which parameter to use when automapping item data. Updated API to v26.
   - sha: 6769a59cb8e5a8fc6aa0d3c45a2f7b49d39dfff5
     changeNotes: Logging removal.
   - sha: 7d1a6ee57624225bc0e8540101ae6aff3505e090

--- a/template.js
+++ b/template.js
@@ -25,8 +25,8 @@ const toBase64 = require('toBase64');
 ==============================================================================*/
 
 const eventData = getAllEventData();
-const API_VERSION = '25.0';
-const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.4' + (data.enableEventEnhancement ? '-ee' : '');
+const API_VERSION = '26.0';
+const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.5' + (data.enableEventEnhancement ? '-ee' : '');
 
 if (shouldExitEarly(data, eventData)) {
   return data.gtmOnSuccess();
@@ -377,7 +377,6 @@ function addEcommerceData(data, eventData, mappedData) {
     if (items) {
       currencyFromItems = items[0].currency;
 
-      mappedData.custom_data.contents = [];
       mappedData.custom_data.content_type =
         eventData['x-fb-cd-content_type'] || eventData.content_type || 'product';
 
@@ -402,6 +401,7 @@ function addEcommerceData(data, eventData, mappedData) {
       }
 
       const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
+      const mapItemDataTo = data.mapItemDataTo || 'contents';
       items.forEach((d) => {
         const content = {};
         if (d[itemIdKey]) content.id = d[itemIdKey];
@@ -415,7 +415,14 @@ function addEcommerceData(data, eventData, mappedData) {
           valueFromItems += d.quantity ? d.quantity * content.item_price : content.item_price;
         }
 
-        mappedData.custom_data.contents.push(content);
+        if (mapItemDataTo === 'contents' || mapItemDataTo === 'both') {
+          mappedData.custom_data.contents = mappedData.custom_data.contents || [];
+          mappedData.custom_data.contents.push(content);
+        }
+        if (content.id && (mapItemDataTo === 'content_ids' || mapItemDataTo === 'both')) {
+          mappedData.custom_data.content_ids = mappedData.custom_data.content_ids || [];
+          mappedData.custom_data.content_ids.push(content.id);
+        }
       });
     }
 

--- a/template.tpl
+++ b/template.tpl
@@ -386,7 +386,7 @@ ___TEMPLATE_PARAMETERS___
       {
         "type": "CHECKBOX",
         "name": "generateFbp",
-        "checkboxText": "Generate _fbp cookie if it not exist",
+        "checkboxText": "Generate _fbp cookie if it does not exist",
         "simpleValueType": true,
         "defaultValue": true,
         "alwaysInSummary": true
@@ -851,20 +851,50 @@ ___TEMPLATE_PARAMETERS___
         "checkboxText": "Automap Custom Data",
         "simpleValueType": true,
         "help": "If enabled, the tag will attempt to automatically map parameters from your event data.\n\u003cbr/\u003e\u003cbr/\u003e\nAny value you manually enter in a field below will always override the auto-mapped value.\n\u003cbr/\u003e\u003cbr/\u003e\nDefault mappings:\n\u003cul\u003e\n\u003cli\u003eValue:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData[\u0027x-ga-mp1-ev\u0027]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eeventData[\u0027x-ga-mp1-tr\u0027]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eeventData.value\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eSum of Price * Quantity from eventData.items[] or eventData.ecommerce.items[]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003e0\u003c/i\u003e, if event is \"Purchase\" and no value is defined\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003cli\u003eCurrency:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData.currency\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eCurrency from eventData.items[] or eventData.ecommerce.items[]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eUSD\u003c/i\u003e, if event is \"Purchase\" and no currency is defined\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003cli\u003eContents:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData.items[]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eeventData.ecommerce.items[]\u003c/i\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003cli\u003eContent Type:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData[x-fb-cd-content_type]\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003e\u003ci\u003eeventData.content_type\u003c/i\u003e\u003c/li\u003e\n\u003cli\u003eDefault: \u003ci\u003eproduct\u003c/i\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003cli\u003eOrder ID:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData.transaction_id\u003c/i\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003cli\u003eSearch String:\n\u003cul\u003e\n\u003cli\u003e\u003ci\u003eeventData.search_term\u003c/i\u003e\u003c/li\u003e\n\u003c/ul\u003e\n\u003c/li\u003e\n\u003c/ul\u003e",
-        "defaultValue": true
-      },
-      {
-        "type": "TEXT",
-        "name": "itemIdKey",
-        "displayName": "Custom Item ID Key",
-        "simpleValueType": true,
-        "help": "Optional.\n\u003cbr/\u003e\u003cbr/\u003e\nYou can specify a custom key, which will be used to set the content Item ID, by default \u003ci\u003eitem_id\u003c/i\u003e will be used. This may be useful if you are using WooCommerce extensions.",
-        "canBeEmptyString": true,
-        "enablingConditions": [
+        "defaultValue": true,
+        "subParams": [
           {
-            "paramName": "autoMapCustomData",
-            "paramValue": false,
-            "type": "NOT_EQUALS"
+            "type": "GROUP",
+            "name": "autoMapCustomDataSettingsGroup",
+            "subParams": [
+              {
+                "type": "TEXT",
+                "name": "itemIdKey",
+                "displayName": "Custom Item ID Key",
+                "simpleValueType": true,
+                "help": "Optional.\n\u003cbr/\u003e\u003cbr/\u003e\nYou can specify a custom key, which will be used to set the content Item ID, by default \u003ci\u003eitem_id\u003c/i\u003e will be used. This may be useful if you are using WooCommerce extensions.",
+                "canBeEmptyString": true
+              },
+              {
+                "type": "SELECT",
+                "name": "mapItemDataTo",
+                "displayName": "Map item data to",
+                "selectItems": [
+                  {
+                    "value": "contents",
+                    "displayValue": "Contents"
+                  },
+                  {
+                    "value": "content_ids",
+                    "displayValue": "Content IDs"
+                  },
+                  {
+                    "value": "both",
+                    "displayValue": "Both Contents and Content IDs"
+                  }
+                ],
+                "simpleValueType": true,
+                "defaultValue": "contents",
+                "help": "Choose which parameter(s) to use when mapping item data: Contents, Content IDs or both."
+              }
+            ],
+            "enablingConditions": [
+              {
+                "paramName": "autoMapCustomData",
+                "paramValue": false,
+                "type": "NOT_EQUALS"
+              }
+            ]
           }
         ]
       },
@@ -1012,8 +1042,8 @@ const toBase64 = require('toBase64');
 ==============================================================================*/
 
 const eventData = getAllEventData();
-const API_VERSION = '25.0';
-const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.4' + (data.enableEventEnhancement ? '-ee' : '');
+const API_VERSION = '26.0';
+const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.5' + (data.enableEventEnhancement ? '-ee' : '');
 
 if (shouldExitEarly(data, eventData)) {
   return data.gtmOnSuccess();
@@ -1364,7 +1394,6 @@ function addEcommerceData(data, eventData, mappedData) {
     if (items) {
       currencyFromItems = items[0].currency;
 
-      mappedData.custom_data.contents = [];
       mappedData.custom_data.content_type =
         eventData['x-fb-cd-content_type'] || eventData.content_type || 'product';
 
@@ -1389,6 +1418,7 @@ function addEcommerceData(data, eventData, mappedData) {
       }
 
       const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
+      const mapItemDataTo = data.mapItemDataTo || 'contents';
       items.forEach((d) => {
         const content = {};
         if (d[itemIdKey]) content.id = d[itemIdKey];
@@ -1402,7 +1432,14 @@ function addEcommerceData(data, eventData, mappedData) {
           valueFromItems += d.quantity ? d.quantity * content.item_price : content.item_price;
         }
 
-        mappedData.custom_data.contents.push(content);
+        if (mapItemDataTo === 'contents' || mapItemDataTo === 'both') {
+          mappedData.custom_data.contents = mappedData.custom_data.contents || [];
+          mappedData.custom_data.contents.push(content);
+        }
+        if (content.id && (mapItemDataTo === 'content_ids' || mapItemDataTo === 'both')) {
+          mappedData.custom_data.content_ids = mappedData.custom_data.content_ids || [];
+          mappedData.custom_data.content_ids.push(content.id);
+        }
       });
     }
 
@@ -2404,7 +2441,7 @@ setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\ncons
   \ 'TraceId', 'Name'];\nconst requiredBqKeys = ['timestamp', 'type', 'trace_id',\
   \ 'tag_name'];\nconst expectedBqOptions = { ignoreUnknownValues: true };\n\nconst\
   \ expectedValue = 'test';\nconst expectedPixelId = '1111111111111';\nconst expectedPartnerAgent\
-  \ = 'stape-gtmss-2.1.4';\nconst expectedApiVersion = '25.0';\n\n\nconst mockData\
+  \ = 'stape-gtmss-2.1.5';\nconst expectedApiVersion = '26.0';\n\n\nconst mockData\
   \ = {\n  pixelId: expectedPixelId,\n  accessToken: expectedValue,\n  inheritEventName:\
   \ 'override',\n  eventNameCustom: expectedValue,\n  logBigQueryProjectId: expectedBigQuerySettings.logBigQueryProjectId,\n\
   \  logBigQueryDatasetId: expectedBigQuerySettings.logBigQueryDatasetId,\n  logBigQueryTableId:\
@@ -2418,6 +2455,10 @@ setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\ncons
 
 
 ___NOTES___
+
+2026-08-25 Change Notes:
+ - Add option to map item data to contents, content_ids or both.
+ - Bump API version to 26.0.
 
 2026-05-25 Change Notes:
  - Logging removal.


### PR DESCRIPTION
This pull request introduces a new feature that allows users to control how item data is mapped in ecommerce events, specifically giving the option to map item data to `contents`, `content_ids`, or both. This is achieved through new template parameters and corresponding logic updates in the code, enhancing flexibility for different integration scenarios.

**Ecommerce item data mapping enhancements:**

* Added a new `mapItemDataTo` parameter in the template configuration (`template.tpl`) that lets users choose to map item data to `contents`, `content_ids`, or both. The UI now presents this as a select field when automapping is disabled.
* Updated the `addEcommerceData` function in both `template.js` and `template.tpl` to use the `mapItemDataTo` parameter. The logic now conditionally populates `mappedData.custom_data.contents` and/or `mappedData.custom_data.content_ids` based on the selected option. [[1]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R404) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R1421) [[3]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R418-R425) [[4]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292R1435-R1442)
* Removed unconditional clearing of `mappedData.custom_data.contents` to prevent overwriting when only `content_ids` is selected. [[1]](diffhunk://#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210L380) [[2]](diffhunk://#diff-dfeab1de57b435942d72fd2eef60b735ad864ee7b35692d09d05d0536ffce292L1367)

**Documentation and notes:**

* Added change notes to `template.tpl` summarizing the new mapping option for item data.

These changes make the template more adaptable to various ecommerce tracking requirements and improve user control over data mapping.