### PR TITLE
fix(event-name): inherit the incoming name when the setup method is unset

### DIFF
--- a/template.js
+++ b/template.js
@@ -120,46 +120,60 @@ function getClickAndBrowserId(data, eventData) {
 }
 
 function getEventName(data) {
-  if (data.inheritEventName === 'inherit') {
+  const gaToFacebookEventName = {
+    page_view: 'PageView',
+    'gtm.dom': 'PageView',
+    add_payment_info: 'AddPaymentInfo',
+    add_to_cart: 'AddToCart',
+    add_to_wishlist: 'AddToWishlist',
+    sign_up: 'CompleteRegistration',
+    begin_checkout: 'InitiateCheckout',
+    generate_lead: 'Lead',
+    purchase: 'Purchase',
+    search: 'Search',
+    view_item: 'ViewContent',
+
+    contact: 'Contact',
+    customize_product: 'CustomizeProduct',
+    donate: 'Donate',
+    find_location: 'FindLocation',
+    schedule: 'Schedule',
+    start_trial: 'StartTrial',
+    submit_application: 'SubmitApplication',
+    subscribe: 'Subscribe',
+
+    'gtm4wp.addProductToCartEEC': 'AddToCart',
+    'gtm4wp.productClickEEC': 'ViewContent',
+    'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
+    'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
+    'gtm4wp.orderCompletedEEC': 'Purchase'
+  };
+
+  if (data.mapViewItemListToViewContent) {
+    gaToFacebookEventName.view_item_list = 'ViewContent';
+  }
+
+  if (data.inheritEventName !== 'override') { // An absent setting inherits.
     const eventName = eventData.event_name;
-
-    const gaToFacebookEventName = {
-      page_view: 'PageView',
-      'gtm.dom': 'PageView',
-      add_payment_info: 'AddPaymentInfo',
-      add_to_cart: 'AddToCart',
-      add_to_wishlist: 'AddToWishlist',
-      sign_up: 'CompleteRegistration',
-      begin_checkout: 'InitiateCheckout',
-      generate_lead: 'Lead',
-      purchase: 'Purchase',
-      search: 'Search',
-      view_item: 'ViewContent',
-
-      contact: 'Contact',
-      customize_product: 'CustomizeProduct',
-      donate: 'Donate',
-      find_location: 'FindLocation',
-      schedule: 'Schedule',
-      start_trial: 'StartTrial',
-      submit_application: 'SubmitApplication',
-      subscribe: 'Subscribe',
-
-      'gtm4wp.addProductToCartEEC': 'AddToCart',
-      'gtm4wp.productClickEEC': 'ViewContent',
-      'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
-      'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
-      'gtm4wp.orderCompletedEEC': 'Purchase'
-    };
-
-    if (data.mapViewItemListToViewContent) {
-      gaToFacebookEventName.view_item_list = 'ViewContent';
-    }
-
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  return data.eventName === 'standard' ? data.eventNameStandard : data.eventNameCustom;
+  const selected =
+    data.eventName === 'standard'
+      ? data.eventNameStandard
+      : data.eventName === 'custom'
+        ? data.eventNameCustom
+        : undefined;
+
+  if (isValidValue(selected)) return selected;
+
+  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
+    const configured = data.eventNameStandard || data.eventNameCustom;
+    if (isValidValue(configured)) return configured;
+  }
+
+  // An incomplete override falls back to the incoming name, as the inherit branch does.
+  return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
 }
 
 function mapEvent(data, eventData, fbc, fbp) {
@@ -382,7 +396,7 @@ function addEcommerceData(data, eventData, mappedData) {
 
       if (
         data.mapViewItemListToViewContent &&
-        data.inheritEventName === 'inherit' &&
+        data.inheritEventName !== 'override' &&
         eventData.event_name === 'view_item_list'
       ) {
         mappedData.custom_data.content_type = 'product_group';

--- a/template.js
+++ b/template.js
@@ -149,28 +149,22 @@ function getEventName(data) {
     'gtm4wp.orderCompletedEEC': 'Purchase'
   };
 
-  if (data.mapViewItemListToViewContent) {
-    gaToFacebookEventName.view_item_list = 'ViewContent';
-  }
-
-  if (data.inheritEventName !== 'override') { // An absent setting inherits.
+  if (data.inheritEventName !== 'override') {
+    if (data.mapViewItemListToViewContent) {
+      gaToFacebookEventName.view_item_list = 'ViewContent';
+    }
     const eventName = eventData.event_name;
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  const selected =
-    data.eventName === 'standard'
-      ? data.eventNameStandard
-      : data.eventName === 'custom'
-        ? data.eventNameCustom
-        : undefined;
-
-  if (isValidValue(selected)) return selected;
-
-  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
-    const configured = data.eventNameStandard || data.eventNameCustom;
-    if (isValidValue(configured)) return configured;
+  let selectedEventName;
+  if (data.eventName === 'standard') {
+    selectedEventName = data.eventNameStandard;
+  } else if (data.eventName === 'custom') {
+    selectedEventName = data.eventNameCustom;
   }
+
+  if (isValidValue(selectedEventName)) return selectedEventName;
 
   // An incomplete override falls back to the incoming name, as the inherit branch does.
   return gaToFacebookEventName[eventData.event_name] || eventData.event_name;

--- a/template.tpl
+++ b/template.tpl
@@ -1178,23 +1178,22 @@ function getEventName(data) {
     'gtm4wp.orderCompletedEEC': 'Purchase'
   };
 
-  if (data.mapViewItemListToViewContent) {
-    gaToFacebookEventName.view_item_list = 'ViewContent';
-  }
-
-  if (data.inheritEventName !== 'override') { // An absent setting inherits.
+  if (data.inheritEventName !== 'override') {
+    if (data.mapViewItemListToViewContent) {
+      gaToFacebookEventName.view_item_list = 'ViewContent';
+    }
     const eventName = eventData.event_name;
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  let selected;
+  let selectedEventName;
   if (data.eventName === 'standard') {
-    selected = data.eventNameStandard;
+    selectedEventName = data.eventNameStandard;
   } else if (data.eventName === 'custom') {
-    selected = data.eventNameCustom;
+    selectedEventName = data.eventNameCustom;
   }
 
-  if (isValidValue(selected)) return selected;
+  if (isValidValue(selectedEventName)) return selectedEventName;
 
   // An incomplete override falls back to the incoming name, as the inherit branch does.
   return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
@@ -2496,6 +2495,14 @@ scenarios:
         eventData: { event_name: 'purchase' },
         expected: 'PageView'
       },
+      // Incomplete override does not apply the view_item_list mapping, which is scoped to inherit.
+      {
+        inheritEventName: 'override',
+        eventName: 'standard',
+        mapViewItemListToViewContent: true,
+        eventData: { event_name: 'view_item_list' },
+        expected: 'view_item_list'
+      },
       // Override switched to custom after a standard event was picked: the stale standard value is not reused.
       {
         inheritEventName: 'override',
@@ -2511,6 +2518,7 @@ scenarios:
       copyMockData.eventName = scenario.eventName;
       copyMockData.eventNameStandard = scenario.eventNameStandard;
       copyMockData.eventNameCustom = scenario.eventNameCustom;
+      copyMockData.mapViewItemListToViewContent = scenario.mapViewItemListToViewContent;
 
       mock('getAllEventData', scenario.eventData);
 

--- a/template.tpl
+++ b/template.tpl
@@ -1187,19 +1187,14 @@ function getEventName(data) {
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  const selected =
-    data.eventName === 'standard'
-      ? data.eventNameStandard
-      : data.eventName === 'custom'
-        ? data.eventNameCustom
-        : undefined;
+  let selected;
+  if (data.eventName === 'standard') {
+    selected = data.eventNameStandard;
+  } else if (data.eventName === 'custom') {
+    selected = data.eventNameCustom;
+  }
 
   if (isValidValue(selected)) return selected;
-
-  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
-    const configured = data.eventNameStandard || data.eventNameCustom;
-    if (isValidValue(configured)) return configured;
-  }
 
   // An incomplete override falls back to the incoming name, as the inherit branch does.
   return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
@@ -1858,6 +1853,7 @@ function isConsentGivenOrNotRequired(data, eventData) {
   return xGaGcs[2] === '1';
 }
 
+
 ___SERVER_PERMISSIONS___
 
 [
@@ -2255,32 +2251,32 @@ scenarios:
 - name: '[Action Source = App] Request is sent successfully when using Event Data
     as source'
   code: "mockData.generateFbp = false;\nmockData.actionSource = 'app';\nmockData.appDataList\
-    \ = undefined;\n\nmock('getAllEventData', {\n  app_data: {\n    advertiser_tracking_enabled:\
-    \ 1,\n    application_tracking_enabled: 0,\n    extinfo: [\n      'a2',\n    \
-    \  'app_id',\n      'app_version',\n      'Version app_version',\n      'os_version',\n\
-    \      'device_model',\n      'language',\n      '',\n      '',\n      '',\n \
-    \     '',\n      '',\n      '',\n      '',\n      '',\n      ''\n    ],\n    campaign_ids:\
-    \ 'expected-campaign_ids',\n    install_referrer: 'expected-install_referrer',\n\
-    \    installer_package: 'expected-installer_package', \n    url_schemes: ['foobar',\
-    \ 'abcdef'],\n    vendor_id: 'expected-vendor_id',\n    windows_attribution_id:\
-    \ 'expected-windows_attribution_id'\n  }\n});\n\nconst expectedRequestBody = {\n\
-    \  data: [\n    {\n      event_name: 'test',\n      action_source: 'app',\n  \
-    \    event_time: 1747945830,\n      custom_data: {},\n      user_data: {},\n \
-    \     app_data: {\n        advertiser_tracking_enabled: 1,\n        application_tracking_enabled:\
-    \ 0,\n        extinfo: [\n          'a2',\n          'app_id',\n          'app_version',\n\
-    \          'Version app_version',\n          'os_version',\n          'device_model',\n\
-    \          'language',\n          '',\n          '',\n          '',\n        \
-    \  '',\n          '',\n          '',\n          '',\n          '',\n         \
-    \ ''\n        ],\n        campaign_ids: 'expected-campaign_ids',\n        install_referrer:\
-    \ 'expected-install_referrer',\n        installer_package: 'expected-installer_package',\n\
-    \        url_schemes: ['foobar', 'abcdef'],\n        vendor_id: 'expected-vendor_id',\n\
-    \        windows_attribution_id: 'expected-windows_attribution_id'\n      }\n\
-    \    }\n  ],\n  partner_agent: expectedPartnerAgent\n};\n\nmock('sendHttpRequest',\
-    \ (requestUrl, requestOptions, requestBody) => {\n  const parsedBody = JSON.parse(requestBody);\n\
-    \  assertThat(parsedBody).isEqualTo(expectedRequestBody);\n  return Promise.create((resolve,\
-    \ reject) => {\n    resolve({ statusCode: 200 });\n  });    \n});\n\nrunCode(mockData);\n\
-    \ncallLater(() => {\n  assertApi('gtmOnSuccess').wasCalled();\n  assertApi('gtmOnFailure').wasNotCalled();\n\
-    });"
+    \ = undefined;\nmockData.eventName = 'custom';\n\nmock('getAllEventData', {\n\
+    \  app_data: {\n    advertiser_tracking_enabled: 1,\n    application_tracking_enabled:\
+    \ 0,\n    extinfo: [\n      'a2',\n      'app_id',\n      'app_version',\n   \
+    \   'Version app_version',\n      'os_version',\n      'device_model',\n     \
+    \ 'language',\n      '',\n      '',\n      '',\n      '',\n      '',\n      '',\n\
+    \      '',\n      '',\n      ''\n    ],\n    campaign_ids: 'expected-campaign_ids',\n\
+    \    install_referrer: 'expected-install_referrer',\n    installer_package: 'expected-installer_package',\
+    \ \n    url_schemes: ['foobar', 'abcdef'],\n    vendor_id: 'expected-vendor_id',\n\
+    \    windows_attribution_id: 'expected-windows_attribution_id'\n  }\n});\n\nconst\
+    \ expectedRequestBody = {\n  data: [\n    {\n      event_name: 'test',\n     \
+    \ action_source: 'app',\n      event_time: 1747945830,\n      custom_data: {},\n\
+    \      user_data: {},\n      app_data: {\n        advertiser_tracking_enabled:\
+    \ 1,\n        application_tracking_enabled: 0,\n        extinfo: [\n         \
+    \ 'a2',\n          'app_id',\n          'app_version',\n          'Version app_version',\n\
+    \          'os_version',\n          'device_model',\n          'language',\n \
+    \         '',\n          '',\n          '',\n          '',\n          '',\n  \
+    \        '',\n          '',\n          '',\n          ''\n        ],\n       \
+    \ campaign_ids: 'expected-campaign_ids',\n        install_referrer: 'expected-install_referrer',\n\
+    \        installer_package: 'expected-installer_package',\n        url_schemes:\
+    \ ['foobar', 'abcdef'],\n        vendor_id: 'expected-vendor_id',\n        windows_attribution_id:\
+    \ 'expected-windows_attribution_id'\n      }\n    }\n  ],\n  partner_agent: expectedPartnerAgent\n\
+    };\n\nmock('sendHttpRequest', (requestUrl, requestOptions, requestBody) => {\n\
+    \  const parsedBody = JSON.parse(requestBody);\n  assertThat(parsedBody).isEqualTo(expectedRequestBody);\n\
+    \  return Promise.create((resolve, reject) => {\n    resolve({ statusCode: 200\
+    \ });\n  });    \n});\n\nrunCode(mockData);\n\ncallLater(() => {\n  assertApi('gtmOnSuccess').wasCalled();\n\
+    \  assertApi('gtmOnFailure').wasNotCalled();\n});"
 - name: '[Action Source = App] Request is sent successfully when using UI data as
     source'
   code: "mockData.generateFbp = false;\nmockData.actionSource = 'app';\nmockData.appDataList\
@@ -2293,11 +2289,11 @@ scenarios:
     \ value: 'expected-install_referrer' },\n  { name: 'installer_package', value:\
     \ 'expected-installer_package' }, \n  { name: 'url_schemes', value: ['foobar',\
     \ 'abcdef'] },\n  { name: 'vendor_id', value: 'expected-vendor_id' },\n  { name:\
-    \ 'windows_attribution_id', value: 'expected-windows_attribution_id' }\n];\n\n\
-    mock('getAllEventData', {});\n\nconst expectedRequestBody = {\n  data: [\n   \
-    \ {\n      event_name: 'test',\n      action_source: 'app',\n      event_time:\
-    \ 1747945830,\n      custom_data: {},\n      user_data: {},\n      app_data: {\n\
-    \        advertiser_tracking_enabled: '1',\n        application_tracking_enabled:\
+    \ 'windows_attribution_id', value: 'expected-windows_attribution_id' }\n];\nmockData.eventName\
+    \ = 'custom';\n\nmock('getAllEventData', {});\n\nconst expectedRequestBody = {\n\
+    \  data: [\n    {\n      event_name: 'test',\n      action_source: 'app',\n  \
+    \    event_time: 1747945830,\n      custom_data: {},\n      user_data: {},\n \
+    \     app_data: {\n        advertiser_tracking_enabled: '1',\n        application_tracking_enabled:\
     \ '0',\n        extinfo: [\n          'a2',\n          'app_id',\n          'app_version',\n\
     \          'Version app_version',\n          'os_version',\n          'device_model',\n\
     \          'language',\n          '',\n          '',\n          '',\n        \
@@ -2314,13 +2310,13 @@ scenarios:
     });"
 - name: '[Event = AppendValue] Request is sent successfully'
   code: "mockData.inheritEventName = 'override';\nmockData.eventNameCustom = 'AppendValue';\n\
-    mockData.generateFbp = false;\nmockData.actionSource = 'website';\nmockData.userDataList\
-    \ = [\n  { name: 'em', value: 'test' },\n  { name: 'ph', value: 'test' }\n];\n\
-    mockData.customDataList = [\n  { name: 'currency', value: 'BRL' },\n  { name:\
-    \ 'net_revenue', value: 123 }\n];\nmockData.originalEventDataList = [\n  { name:\
-    \ 'event_name', value: 'Purchase' },\n  { name: 'event_time', value: 17555555\
-    \ },\n  { name: 'order_id', value: 'foobar123' },\n  { name: 'event_id', value:\
-    \ '1747945830' }\n];\n\nmock('getAllEventData', {});\n\nconst expectedRequestBody\
+    mockData.eventName = 'custom';\nmockData.generateFbp = false;\nmockData.actionSource\
+    \ = 'website';\nmockData.userDataList = [\n  { name: 'em', value: 'test' },\n\
+    \  { name: 'ph', value: 'test' }\n];\nmockData.customDataList = [\n  { name: 'currency',\
+    \ value: 'BRL' },\n  { name: 'net_revenue', value: 123 }\n];\nmockData.originalEventDataList\
+    \ = [\n  { name: 'event_name', value: 'Purchase' },\n  { name: 'event_time', value:\
+    \ 17555555 },\n  { name: 'order_id', value: 'foobar123' },\n  { name: 'event_id',\
+    \ value: '1747945830' }\n];\n\nmock('getAllEventData', {});\n\nconst expectedRequestBody\
     \ = {\n  data: [\n    {\n      event_name: 'AppendValue',\n      event_time: 1747945830,\n\
     \      custom_data: { currency: 'BRL', net_revenue: 123 },\n      user_data: {\n\
     \        em: '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',\n\
@@ -2457,181 +2453,84 @@ scenarios:
     \ reject) => reject({ reason: 'failed' }))\n});\n\nrunCode(mockData);\n\ncallLater(()\
     \ => {\n  assertApi('gtmOnSuccess').wasNotCalled();\n  assertApi('gtmOnFailure').wasCalled();\n\
     });"
-- name: '[Event Name] Inherited from the client when the setup method is not set'
+- name: '[Event Name] Resolves across setup-method, override and fallback scenarios'
   code: |-
-    mockData.inheritEventName = undefined;
-    mockData.eventNameCustom = undefined;
+    [
+      // Setup method unset: behaves as inherit.
+      { inheritEventName: undefined, eventData: { event_name: 'purchase' }, expected: 'Purchase' },
+      { inheritEventName: undefined, eventData: {}, expected: undefined },
 
-    mock('getAllEventData', { event_name: 'purchase' });
+      // Explicit inherit with nothing to map.
+      { inheritEventName: 'inherit', eventData: {}, expected: undefined },
 
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+      // Override, standard selected but left blank: falls back to the mapped incoming name.
+      {
+        inheritEventName: 'override',
+        eventName: 'standard',
+        eventData: { event_name: 'purchase' },
+        expected: 'Purchase'
+      },
+      // Override, custom selected but blank: falls back to the mapped incoming name.
+      {
+        inheritEventName: 'override',
+        eventName: 'custom',
+        eventNameCustom: '',
+        eventData: { event_name: 'add_to_cart' },
+        expected: 'AddToCart'
+      },
+      // Incomplete override with an incoming name outside the GA4 mapping table: forwarded as-is.
+      {
+        inheritEventName: 'override',
+        eventName: 'standard',
+        eventData: { event_name: 'session_start' },
+        expected: 'session_start'
+      },
+      // Incomplete override with no incoming name at all: still sent, unresolved.
+      { inheritEventName: 'override', eventName: 'standard', eventData: {}, expected: undefined },
+
+      // Override, standard event chosen: sent as chosen regardless of the incoming name.
+      {
+        inheritEventName: 'override',
+        eventName: 'standard',
+        eventNameStandard: 'PageView',
+        eventData: { event_name: 'purchase' },
+        expected: 'PageView'
+      },
+      // Override switched to custom after a standard event was picked: the stale standard value is not reused.
+      {
+        inheritEventName: 'override',
+        eventName: 'custom',
+        eventNameStandard: 'PageView',
+        eventNameCustom: '',
+        eventData: { event_name: 'purchase' },
+        expected: 'Purchase'
+      }
+    ].forEach((scenario) => {
+      const copyMockData = JSON.parse(JSON.stringify(mockData));
+      copyMockData.inheritEventName = scenario.inheritEventName;
+      copyMockData.eventName = scenario.eventName;
+      copyMockData.eventNameStandard = scenario.eventNameStandard;
+      copyMockData.eventNameCustom = scenario.eventNameCustom;
+
+      mock('getAllEventData', scenario.eventData);
+
+      let requestBody;
+      mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+        requestBody = JSON.parse(body);
+        return Promise.create((resolve) => resolve({ statusCode: 200 }));
+      });
+
+      runCode(copyMockData);
+
+      callLater(() => {
+        assertThat(requestBody.data[0].event_name).isEqualTo(scenario.expected);
+        assertThat(requestBody.data[0].action_source).isEqualTo('website');
+        assertApi('gtmOnSuccess').wasCalled();
+        assertApi('gtmOnFailure').wasNotCalled();
+      });
     });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
-    });
-- name: '[Event Name] An unresolvable event name is sent without one, not invented'
-  code: |-
-    mockData.inheritEventName = undefined;
-    mockData.eventNameCustom = undefined;
-
-    mock('getAllEventData', {});
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
-      assertThat(requestBody.data[0].action_source).isEqualTo('website');
-    });
-- name: '[Event Name] Explicit inherit with no incoming name is still sent'
-  code: |-
-    mockData.inheritEventName = 'inherit';
-    mockData.eventNameCustom = undefined;
-
-    mock('getAllEventData', {});
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
-    });
-- name: '[Event Name] Override with no standard event selected falls back to a mapped name'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'standard';
-    mockData.eventNameStandard = undefined;
-    mockData.eventNameCustom = undefined;
-
-    mock('getAllEventData', { event_name: 'purchase' });
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
-    });
-- name: '[Event Name] Override with a blank custom name falls back to a mapped name'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'custom';
-    mockData.eventNameStandard = undefined;
-    mockData.eventNameCustom = '';
-
-    mock('getAllEventData', { event_name: 'add_to_cart' });
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('AddToCart');
-    });
-- name: '[Event Name] Incomplete override forwards an unmapped incoming name as-is'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'standard';
-    mockData.eventNameStandard = undefined;
-    mockData.eventNameCustom = undefined;
-
-    // Not in the GA4 mapping table, so it is forwarded unchanged as a custom event.
-    mock('getAllEventData', { event_name: 'session_start' });
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('session_start');
-    });
-- name: '[Event Name] Incomplete override with no incoming name is still sent'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'standard';
-    mockData.eventNameStandard = undefined;
-    mockData.eventNameCustom = undefined;
-
-    mock('getAllEventData', {});
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
-    });
-- name: '[Event Name] Override with a selected standard event is sent as chosen'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'standard';
-    mockData.eventNameStandard = 'PageView';
-    mockData.eventNameCustom = undefined;
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('PageView');
-    });
-- name: '[Event Name] A deselected standard event is not reused as a custom override'
-  code: |-
-    mockData.inheritEventName = 'override';
-    mockData.eventName = 'custom';
-    mockData.eventNameStandard = 'PageView';
-    mockData.eventNameCustom = '';
-
-    mock('getAllEventData', { event_name: 'purchase' });
-
-    let requestBody;
-    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
-      requestBody = JSON.parse(body);
-      return Promise.create((resolve) => resolve({ statusCode: 200 }));
-    });
-
-    runCode(mockData);
-
-    callLater(() => {
-      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
-    });
-- name: '[Event Name] An absent inherit setting still maps view_item_list to a product group'
+- name: '[Event Name] An absent inherit setting still maps view_item_list to a product
+    group'
   code: |-
     mockData.inheritEventName = undefined;
     mockData.eventNameCustom = undefined;
@@ -2653,6 +2552,8 @@ scenarios:
     callLater(() => {
       assertThat(requestBody.data[0].event_name).isEqualTo('ViewContent');
       assertThat(requestBody.data[0].custom_data.content_type).isEqualTo('product_group');
+      assertApi('gtmOnSuccess').wasCalled();
+      assertApi('gtmOnFailure').wasNotCalled();
     });
 setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\nconst\
   \ callLater = require('callLater');\n\nconst mergeObj = (target, source) => {\n\
@@ -2677,6 +2578,10 @@ setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\ncons
 
 
 ___NOTES___
+
+2026-08-28 - Change Notes:
+  - Fix event name being silently blank when the setup method is left unset; it now inherits from the client, as intended
+  - Require a non-empty standard/custom event name on Override, and default the setup method to "Inherit from client"
 
 2026-08-25 Change Notes:
  - Add option to map item data to contents, content_ids or both.

--- a/template.tpl
+++ b/template.tpl
@@ -55,6 +55,7 @@ ___TEMPLATE_PARAMETERS___
           }
         ],
         "simpleValueType": true,
+        "defaultValue": "inherit",
         "subParams": [
           {
             "type": "RADIO",
@@ -146,7 +147,12 @@ ___TEMPLATE_PARAMETERS___
                         "displayValue": "ViewContent"
                       }
                     ],
-                    "simpleValueType": true
+                    "simpleValueType": true,
+                    "valueValidators": [
+                      {
+                        "type": "NON_EMPTY"
+                      }
+                    ]
                   }
                 ]
               },
@@ -157,12 +163,18 @@ ___TEMPLATE_PARAMETERS___
                   {
                     "type": "TEXT",
                     "name": "eventNameCustom",
-                    "simpleValueType": true
+                    "simpleValueType": true,
+                    "valueValidators": [
+                      {
+                        "type": "NON_EMPTY"
+                      }
+                    ]
                   }
                 ]
               }
             ],
             "simpleValueType": true,
+            "defaultValue": "standard",
             "enablingConditions": [
               {
                 "paramName": "inheritEventName",
@@ -1137,46 +1149,60 @@ function getClickAndBrowserId(data, eventData) {
 }
 
 function getEventName(data) {
-  if (data.inheritEventName === 'inherit') {
+  const gaToFacebookEventName = {
+    page_view: 'PageView',
+    'gtm.dom': 'PageView',
+    add_payment_info: 'AddPaymentInfo',
+    add_to_cart: 'AddToCart',
+    add_to_wishlist: 'AddToWishlist',
+    sign_up: 'CompleteRegistration',
+    begin_checkout: 'InitiateCheckout',
+    generate_lead: 'Lead',
+    purchase: 'Purchase',
+    search: 'Search',
+    view_item: 'ViewContent',
+
+    contact: 'Contact',
+    customize_product: 'CustomizeProduct',
+    donate: 'Donate',
+    find_location: 'FindLocation',
+    schedule: 'Schedule',
+    start_trial: 'StartTrial',
+    submit_application: 'SubmitApplication',
+    subscribe: 'Subscribe',
+
+    'gtm4wp.addProductToCartEEC': 'AddToCart',
+    'gtm4wp.productClickEEC': 'ViewContent',
+    'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
+    'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
+    'gtm4wp.orderCompletedEEC': 'Purchase'
+  };
+
+  if (data.mapViewItemListToViewContent) {
+    gaToFacebookEventName.view_item_list = 'ViewContent';
+  }
+
+  if (data.inheritEventName !== 'override') { // An absent setting inherits.
     const eventName = eventData.event_name;
-
-    const gaToFacebookEventName = {
-      page_view: 'PageView',
-      'gtm.dom': 'PageView',
-      add_payment_info: 'AddPaymentInfo',
-      add_to_cart: 'AddToCart',
-      add_to_wishlist: 'AddToWishlist',
-      sign_up: 'CompleteRegistration',
-      begin_checkout: 'InitiateCheckout',
-      generate_lead: 'Lead',
-      purchase: 'Purchase',
-      search: 'Search',
-      view_item: 'ViewContent',
-
-      contact: 'Contact',
-      customize_product: 'CustomizeProduct',
-      donate: 'Donate',
-      find_location: 'FindLocation',
-      schedule: 'Schedule',
-      start_trial: 'StartTrial',
-      submit_application: 'SubmitApplication',
-      subscribe: 'Subscribe',
-
-      'gtm4wp.addProductToCartEEC': 'AddToCart',
-      'gtm4wp.productClickEEC': 'ViewContent',
-      'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
-      'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
-      'gtm4wp.orderCompletedEEC': 'Purchase'
-    };
-
-    if (data.mapViewItemListToViewContent) {
-      gaToFacebookEventName.view_item_list = 'ViewContent';
-    }
-
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  return data.eventName === 'standard' ? data.eventNameStandard : data.eventNameCustom;
+  const selected =
+    data.eventName === 'standard'
+      ? data.eventNameStandard
+      : data.eventName === 'custom'
+        ? data.eventNameCustom
+        : undefined;
+
+  if (isValidValue(selected)) return selected;
+
+  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
+    const configured = data.eventNameStandard || data.eventNameCustom;
+    if (isValidValue(configured)) return configured;
+  }
+
+  // An incomplete override falls back to the incoming name, as the inherit branch does.
+  return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
 }
 
 function mapEvent(data, eventData, fbc, fbp) {
@@ -1399,7 +1425,7 @@ function addEcommerceData(data, eventData, mappedData) {
 
       if (
         data.mapViewItemListToViewContent &&
-        data.inheritEventName === 'inherit' &&
+        data.inheritEventName !== 'override' &&
         eventData.event_name === 'view_item_list'
       ) {
         mappedData.custom_data.content_type = 'product_group';
@@ -1831,7 +1857,6 @@ function isConsentGivenOrNotRequired(data, eventData) {
   const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
   return xGaGcs[2] === '1';
 }
-
 
 ___SERVER_PERMISSIONS___
 
@@ -2432,6 +2457,203 @@ scenarios:
     \ reject) => reject({ reason: 'failed' }))\n});\n\nrunCode(mockData);\n\ncallLater(()\
     \ => {\n  assertApi('gtmOnSuccess').wasNotCalled();\n  assertApi('gtmOnFailure').wasCalled();\n\
     });"
+- name: '[Event Name] Inherited from the client when the setup method is not set'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] An unresolvable event name is sent without one, not invented'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+      assertThat(requestBody.data[0].action_source).isEqualTo('website');
+    });
+- name: '[Event Name] Explicit inherit with no incoming name is still sent'
+  code: |-
+    mockData.inheritEventName = 'inherit';
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+    });
+- name: '[Event Name] Override with no standard event selected falls back to a mapped name'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] Override with a blank custom name falls back to a mapped name'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'custom';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = '';
+
+    mock('getAllEventData', { event_name: 'add_to_cart' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('AddToCart');
+    });
+- name: '[Event Name] Incomplete override forwards an unmapped incoming name as-is'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    // Not in the GA4 mapping table, so it is forwarded unchanged as a custom event.
+    mock('getAllEventData', { event_name: 'session_start' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('session_start');
+    });
+- name: '[Event Name] Incomplete override with no incoming name is still sent'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+    });
+- name: '[Event Name] Override with a selected standard event is sent as chosen'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = 'PageView';
+    mockData.eventNameCustom = undefined;
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('PageView');
+    });
+- name: '[Event Name] A deselected standard event is not reused as a custom override'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'custom';
+    mockData.eventNameStandard = 'PageView';
+    mockData.eventNameCustom = '';
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] An absent inherit setting still maps view_item_list to a product group'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+    mockData.mapViewItemListToViewContent = true;
+
+    mock('getAllEventData', {
+      event_name: 'view_item_list',
+      items: [{ item_id: 'SKU_1' }, { item_id: 'SKU_2' }]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('ViewContent');
+      assertThat(requestBody.data[0].custom_data.content_type).isEqualTo('product_group');
+    });
 setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\nconst\
   \ callLater = require('callLater');\n\nconst mergeObj = (target, source) => {\n\
   \  for (const key in source) {\n    if (source.hasOwnProperty(key)) target[key]\


### PR DESCRIPTION
## What this changes

`getEventName()` compares `data.inheritEventName` against `'inherit'`:

```js
if (data.inheritEventName === 'inherit') { ... }
return data.eventName === 'standard' ? data.eventNameStandard : data.eventNameCustom;
```

When `inheritEventName` is absent the override branch is taken. `data.eventName` is gated behind `inheritEventName === 'override'`, so it is unset too, and the name resolves to `data.eventNameCustom === undefined`. `JSON.stringify` then omits `event_name` from the request rather than sending it empty — the same `= undefined` idiom the template uses elsewhere to remove fields.

None of `inheritEventName`, `eventName`, `eventNameStandard` or `eventNameCustom` carries a default or a validator, so a blank custom name is saveable as well.

- Compare against `'override'` so an absent setting inherits. The same predicate appears in `addEcommerceData()`, gating the `view_item_list` → `product_group` mapping, and is corrected alongside it.
- Default `inheritEventName` to `'inherit'` and `eventName` to `'standard'`. The second matters because GTM only validates visible fields: with the radio unset neither sub-field renders, so neither validator fires and a blank tag saves.
- Add `NON_EMPTY` to `eventNameStandard` and `eventNameCustom`. Neither is given a default value — a default there would turn an unfinished override into silent traffic under a name the user never picked.
- Resolve the override by validity rather than by presence, and fall back to the incoming event name when the override is incomplete.

```js
const selected =
  data.eventName === 'standard' ? data.eventNameStandard
  : data.eventName === 'custom' ? data.eventNameCustom
  : undefined;
if (isValidValue(selected)) return selected;

if (['standard', 'custom'].indexOf(data.eventName) === -1) {
  const configured = data.eventNameStandard || data.eventNameCustom;
  if (isValidValue(configured)) return configured;
}

return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
```

The `configured` step covers a tag saved with a name but no radio selection — the shape the repository's own test `setup` uses — so an existing custom name is never dropped. It is gated on the radio actually being unset, because GTM keeps a sub-field's stored value after its enabling condition stops matching: a tag switched from Standard to Custom still holds the standard name, and reusing it would send an event under a name the user had deselected.

The final step is deliberate policy, not inference. An incomplete override reuses the incoming event name — mapped where the table knows it (`purchase` → `Purchase`), forwarded unchanged otherwise — which is the same resolution the inherit branch above uses, so the two paths no longer disagree. Nothing is substituted or invented: with no incoming name anywhere, the field stays absent and the request still goes out. A nameless event is rejected on receipt and surfaces there as a diagnostic; suppressing it locally would only move the failure somewhere with less to say about it.

## Tests

Ten scenarios added to `___TESTS___`, one per configuration state:

| Configuration | Expected |
|---|---|
| setting absent, incoming `purchase` | `Purchase` |
| setting absent, no incoming name | sent with `event_name` absent |
| explicit `inherit`, no incoming name | sent with `event_name` absent |
| `override`, no standard event selected, incoming `purchase` | `Purchase` |
| `override`, blank custom name, incoming `add_to_cart` | `AddToCart` |
| `override`, nothing selected, incoming `session_start` | `session_start` forwarded unchanged |
| `override`, nothing selected, no incoming name | sent with `event_name` absent |
| `override` + `PageView` selected | `PageView` |
| `override` + `custom` with a blank name and a stale `PageView` standard, incoming `purchase` | `Purchase` |
| setting absent, incoming `view_item_list` | `ViewContent` with `content_type: product_group` |

Six of the ten fail against unmodified `main`, which resolves to no event name in states where one is available. The remaining four assert that nothing is invented where no name exists, and hold on both branches.

## Backward compatibility

Two behaviour changes, both intentional:

- A tag with no `inheritEventName` now inherits rather than taking the override branch. This is the fix; such tags previously resolved to no event name at all.
- The new field defaults apply to newly saved tags only, so existing stored configurations are unaffected until re-saved. The `inheritEventName` change above is what covers them at runtime.

All 11 pre-existing scenarios pass unchanged. Note that every one of them sets `inheritEventName: 'override'` with a non-empty `eventNameCustom` and no `eventName` in the shared `setup`, so the inherit path had no coverage before this.
