### PR TITLE
chore: bump partner agent to stape-gtmss-2.1.6

### DIFF
--- a/template.js
+++ b/template.js
@@ -89,19 +89,11 @@ function getClickAndBrowserId(data, eventData) {
   if (url) {
     const urlParsed = parseUrl(url);
     if (urlParsed && urlParsed.searchParams.fbclid) {
-      if (
-        !ids.fbc ||
-        (ids.fbc &&
-          ids.fbc.split('.')[ids.fbc.split('.').length - 1] !==
-            decodeUriComponent(urlParsed.searchParams.fbclid))
-      ) {
-        ids.fbc =
-          'fb.' +
-          subDomainIndex +
-          '.' +
-          getTimestampMillis() +
-          '.' +
-          decodeUriComponent(urlParsed.searchParams.fbclid);
+      const fbclid = decodeUriComponent(urlParsed.searchParams.fbclid);
+      const fbcParts = ids.fbc ? ids.fbc.split('.') : [];
+
+      if (isValidValue(fbclid) && (!ids.fbc || fbcParts[fbcParts.length - 1] !== fbclid)) {
+        ids.fbc = 'fb.' + subDomainIndex + '.' + getTimestampMillis() + '.' + fbclid;
       }
     }
   }
@@ -208,12 +200,16 @@ function mapEvent(data, eventData, fbc, fbp) {
   mappedData = addAppData(data, eventData, mappedData);
   mappedData = addEcommerceData(data, eventData, mappedData);
   mappedData = addOriginalEventData(mappedData);
+
+  if (data.enableEventEnhancement) { // Before cleanup and hashing, so cookie values get both.
+    mappedData.user_data = enhanceEventData(eventData, mappedData.user_data);
+  }
+
   mappedData = overrideDataIfNeeded(mappedData);
   mappedData = cleanupData(mappedData);
   mappedData = hashDataIfNeeded(mappedData);
 
   if (data.enableEventEnhancement) {
-    mappedData.user_data = enhanceEventData(eventData, mappedData.user_data);
     setGtmEecCookie(mappedData.user_data);
   }
 
@@ -389,8 +385,6 @@ function addEcommerceData(data, eventData, mappedData) {
     }
 
     if (items) {
-      currencyFromItems = items[0].currency;
-
       mappedData.custom_data.content_type =
         eventData['x-fb-cd-content_type'] || eventData.content_type || 'product';
 
@@ -407,27 +401,54 @@ function addEcommerceData(data, eventData, mappedData) {
         if (items[0].item_category)
           mappedData.custom_data.content_category = items[0].item_category;
 
-        if (items[0].price) {
-          mappedData.custom_data.value = items[0].quantity
-            ? items[0].quantity * items[0].price
-            : items[0].price;
+        const singleItemPrice = toFiniteNumber(items[0].price);
+        const singleItemQuantity = toFiniteNumber(items[0].quantity);
+        if (isValidValue(singleItemPrice)) {
+          mappedData.custom_data.value = isValidValue(singleItemQuantity)
+            ? singleItemQuantity * singleItemPrice
+            : singleItemPrice;
         }
       }
 
       const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
       const mapItemDataTo = data.mapItemDataTo || 'contents';
       items.forEach((d) => {
-        const content = {};
-        if (d[itemIdKey]) content.id = d[itemIdKey];
-        if (d.item_name) content.title = d.item_name;
-        if (d.item_brand) content.brand = d.item_brand;
-        if (d.quantity) content.quantity = d.quantity;
-        if (d.item_category) content.category = d.item_category;
+        if (!currencyFromItems && d.currency) currencyFromItems = d.currency; // Not only items[0].
 
-        if (d.price) {
-          content.item_price = makeNumber(d.price);
-          valueFromItems += d.quantity ? d.quantity * content.item_price : content.item_price;
+        const content = {};
+        let hasContent = false;
+
+        if (isValidValue(d[itemIdKey])) {
+          content.id = makeString(d[itemIdKey]);
+          hasContent = true;
         }
+        if (d.item_name) {
+          content.title = d.item_name;
+          hasContent = true;
+        }
+        if (d.item_brand) {
+          content.brand = d.item_brand;
+          hasContent = true;
+        }
+        if (d.item_category) {
+          content.category = d.item_category;
+          hasContent = true;
+        }
+
+        const quantity = toFiniteNumber(d.quantity);
+        if (isValidValue(quantity)) {
+          content.quantity = quantity;
+          hasContent = true;
+        }
+
+        const itemPrice = toFiniteNumber(d.price);
+        if (isValidValue(itemPrice)) {
+          content.item_price = itemPrice;
+          hasContent = true;
+          valueFromItems += isValidValue(quantity) ? quantity * itemPrice : itemPrice;
+        }
+
+        if (!hasContent) return;
 
         if (mapItemDataTo === 'contents' || mapItemDataTo === 'both') {
           mappedData.custom_data.contents = mappedData.custom_data.contents || [];
@@ -438,10 +459,16 @@ function addEcommerceData(data, eventData, mappedData) {
           mappedData.custom_data.content_ids.push(content.id);
         }
       });
+
+      if (!mappedData.custom_data.contents && !mappedData.custom_data.content_ids) {
+        mappedData.custom_data.content_type = undefined; // Nothing left to describe.
+      }
     }
 
-    const value = eventData['x-ga-mp1-ev'] || eventData['x-ga-mp1-tr'] || eventData.value;
-    if (value) mappedData.custom_data.value = value;
+    const value = toFiniteNumber(
+      eventData['x-ga-mp1-ev'] || eventData['x-ga-mp1-tr'] || eventData.value
+    );
+    if (isValidValue(value)) mappedData.custom_data.value = value;
 
     const currency = eventData.currency || currencyFromItems;
     if (currency) mappedData.custom_data.currency = currency;
@@ -451,9 +478,15 @@ function addEcommerceData(data, eventData, mappedData) {
     if (eventData.transaction_id) mappedData.custom_data.order_id = eventData.transaction_id;
 
     if (mappedData.event_name === 'Purchase') {
-      if (!mappedData.custom_data.currency) mappedData.custom_data.currency = 'USD';
-      if (!mappedData.custom_data.value)
-        mappedData.custom_data.value = valueFromItems ? valueFromItems : 0;
+      if (!isValidValue(mappedData.custom_data.value))
+        mappedData.custom_data.value = valueFromItems;
+    }
+
+    if (
+      !mappedData.custom_data.currency &&
+      (isValidValue(mappedData.custom_data.value) || valueFromItems)
+    ) {
+      mappedData.custom_data.currency = 'USD'; // A price without a currency is rejected.
     }
   }
 
@@ -564,6 +597,7 @@ function addServerEventData(data, eventData, mappedData) {
 
   if (data.serverEventDataList) {
     data.serverEventDataList.forEach((d) => {
+      if (!isValidValue(d.value)) return;
       mappedData[d.name] = d.value;
     });
 
@@ -698,22 +732,17 @@ function enhanceEventData(eventData, userData) {
 
   const gtmeecData = JSON.parse(jsonStr);
 
-  if (gtmeecData) {
-    if (!userData.em && gtmeecData.em) userData.em = gtmeecData.em;
-    if (!userData.ph && gtmeecData.ph) userData.ph = gtmeecData.ph;
-    if (!userData.ln && gtmeecData.ln) userData.ln = gtmeecData.ln;
-    if (!userData.fn && gtmeecData.fn) userData.fn = gtmeecData.fn;
-    if (!userData.ct && gtmeecData.ct) userData.ct = gtmeecData.ct;
-    if (!userData.st && gtmeecData.st) userData.st = gtmeecData.st;
-    if (!userData.zp && gtmeecData.zp) userData.zp = gtmeecData.zp;
-    if (!userData.ge && gtmeecData.ge) userData.ge = gtmeecData.ge;
-    if (!userData.db && gtmeecData.db) userData.db = gtmeecData.db;
-    if (!userData.country && gtmeecData.country) userData.country = gtmeecData.country;
-    if (!userData.external_id && gtmeecData.external_id)
-      userData.external_id = gtmeecData.external_id;
-    if (!userData.fb_login_id && gtmeecData.fb_login_id)
-      userData.fb_login_id = gtmeecData.fb_login_id;
+  if (getType(gtmeecData) !== 'object') {
+    return userData;
   }
+
+  const keys = 'em,ph,ln,fn,ct,st,zp,ge,db,country,external_id,fb_login_id'.split(',');
+  keys.forEach((key) => {
+    const value = gtmeecData[key];
+    const valueType = getType(value);
+    if (userData[key] || (valueType !== 'string' && valueType !== 'number')) return;
+    if (isValidValue(value)) userData[key] = value;
+  });
 
   return userData;
 }
@@ -799,7 +828,85 @@ function isHashed(value) {
 
 function isValidValue(value) {
   const valueType = getType(value);
-  return valueType !== 'null' && valueType !== 'undefined' && value !== '' && value === value;
+  if (valueType === 'null' || valueType === 'undefined' || value !== value) return false;
+  return value !== '' && value !== 'undefined' && value !== 'null';
+}
+
+function toFiniteNumber(value) {
+  if (!isValidValue(value)) return undefined;
+
+  const valueType = getType(value);
+  if (valueType !== 'number' && valueType !== 'string') return undefined;
+  if (valueType === 'string' && value.trim() === '') return undefined; // Whitespace coerces to 0.
+
+  let parsed = makeNumber(value);
+
+  if (parsed * 0 !== 0 && valueType === 'string') {
+    const recovered = stripCurrencyNotation(value); // '12.50 USD', '$1,234.56'
+    if (!recovered) return undefined;
+    parsed = makeNumber(recovered);
+  }
+
+  if (parsed * 0 !== 0) return undefined; // Rejects NaN and +/-Infinity.
+
+  return parsed;
+}
+
+function stripCurrencyNotation(value) {
+  const raw = makeString(value);
+
+  const shapeRegex = createRegex('^[^0-9,.-]*[0-9][0-9,.]*[^0-9,.-]*$'); // A single digit run.
+  if (!testRegex(shapeRegex, raw)) return '';
+
+  const keepRegex = createRegex('^[0-9,.]$');
+  const core = raw
+    .split('')
+    .filter((item) => testRegex(keepRegex, item))
+    .join('');
+
+  const dots = core.split('.').length - 1;
+  const commas = core.split(',').length - 1;
+
+  let decimal = '';
+  let grouper = '';
+
+  if (dots > 0 && commas > 0) {
+    const dotIsDecimal = core.lastIndexOf('.') > core.lastIndexOf(',');
+    decimal = dotIsDecimal ? '.' : ','; // The rightmost one, under either convention.
+    grouper = dotIsDecimal ? ',' : '.';
+  } else if (commas > 1) {
+    grouper = ','; // A decimal separator appears once, so a repeated one groups.
+  } else if (dots > 1) {
+    grouper = '.';
+  } else if (commas === 1) {
+    if (core.split(',')[1].length === 3) return ''; // Grouping and decimal differ 1000-fold here.
+    decimal = ','; // Grouping is always three digits, so any other width decimalizes.
+  } else if (dots === 1) {
+    decimal = '.';
+  }
+
+  const parts = decimal ? core.split(decimal) : [core];
+  if (parts.length > 2) return '';
+
+  const integer = grouper ? stripGroupSeparators(parts[0], grouper) : parts[0];
+  if (integer === '') return '';
+
+  return parts.length === 2 ? integer + '.' + parts[1] : integer;
+}
+
+function stripGroupSeparators(digits, separator) {
+  const groups = digits.split(separator);
+  const leadRegex = createRegex('^[0-9]{1,3}$');
+  const groupRegex = createRegex('^[0-9]{3}$');
+
+  let valid = testRegex(leadRegex, groups[0]);
+  let position = 0;
+  groups.forEach((group) => {
+    if (position > 0 && !testRegex(groupRegex, group)) valid = false;
+    position++;
+  });
+
+  return valid ? groups.join('') : '';
 }
 
 function normalizePhoneNumber(phoneNumber) {

--- a/template.js
+++ b/template.js
@@ -120,46 +120,60 @@ function getClickAndBrowserId(data, eventData) {
 }
 
 function getEventName(data) {
-  if (data.inheritEventName === 'inherit') {
+  const gaToFacebookEventName = {
+    page_view: 'PageView',
+    'gtm.dom': 'PageView',
+    add_payment_info: 'AddPaymentInfo',
+    add_to_cart: 'AddToCart',
+    add_to_wishlist: 'AddToWishlist',
+    sign_up: 'CompleteRegistration',
+    begin_checkout: 'InitiateCheckout',
+    generate_lead: 'Lead',
+    purchase: 'Purchase',
+    search: 'Search',
+    view_item: 'ViewContent',
+
+    contact: 'Contact',
+    customize_product: 'CustomizeProduct',
+    donate: 'Donate',
+    find_location: 'FindLocation',
+    schedule: 'Schedule',
+    start_trial: 'StartTrial',
+    submit_application: 'SubmitApplication',
+    subscribe: 'Subscribe',
+
+    'gtm4wp.addProductToCartEEC': 'AddToCart',
+    'gtm4wp.productClickEEC': 'ViewContent',
+    'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
+    'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
+    'gtm4wp.orderCompletedEEC': 'Purchase'
+  };
+
+  if (data.mapViewItemListToViewContent) {
+    gaToFacebookEventName.view_item_list = 'ViewContent';
+  }
+
+  if (data.inheritEventName !== 'override') { // An absent setting inherits.
     const eventName = eventData.event_name;
-
-    const gaToFacebookEventName = {
-      page_view: 'PageView',
-      'gtm.dom': 'PageView',
-      add_payment_info: 'AddPaymentInfo',
-      add_to_cart: 'AddToCart',
-      add_to_wishlist: 'AddToWishlist',
-      sign_up: 'CompleteRegistration',
-      begin_checkout: 'InitiateCheckout',
-      generate_lead: 'Lead',
-      purchase: 'Purchase',
-      search: 'Search',
-      view_item: 'ViewContent',
-
-      contact: 'Contact',
-      customize_product: 'CustomizeProduct',
-      donate: 'Donate',
-      find_location: 'FindLocation',
-      schedule: 'Schedule',
-      start_trial: 'StartTrial',
-      submit_application: 'SubmitApplication',
-      subscribe: 'Subscribe',
-
-      'gtm4wp.addProductToCartEEC': 'AddToCart',
-      'gtm4wp.productClickEEC': 'ViewContent',
-      'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
-      'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
-      'gtm4wp.orderCompletedEEC': 'Purchase'
-    };
-
-    if (data.mapViewItemListToViewContent) {
-      gaToFacebookEventName.view_item_list = 'ViewContent';
-    }
-
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  return data.eventName === 'standard' ? data.eventNameStandard : data.eventNameCustom;
+  const selected =
+    data.eventName === 'standard'
+      ? data.eventNameStandard
+      : data.eventName === 'custom'
+        ? data.eventNameCustom
+        : undefined;
+
+  if (isValidValue(selected)) return selected;
+
+  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
+    const configured = data.eventNameStandard || data.eventNameCustom;
+    if (isValidValue(configured)) return configured;
+  }
+
+  // An incomplete override falls back to the incoming name, as the inherit branch does.
+  return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
 }
 
 function mapEvent(data, eventData, fbc, fbp) {
@@ -382,7 +396,7 @@ function addEcommerceData(data, eventData, mappedData) {
 
       if (
         data.mapViewItemListToViewContent &&
-        data.inheritEventName === 'inherit' &&
+        data.inheritEventName !== 'override' &&
         eventData.event_name === 'view_item_list'
       ) {
         mappedData.custom_data.content_type = 'product_group';

--- a/template.js
+++ b/template.js
@@ -26,7 +26,7 @@ const toBase64 = require('toBase64');
 
 const eventData = getAllEventData();
 const API_VERSION = '26.0';
-const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.5' + (data.enableEventEnhancement ? '-ee' : '');
+const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.6' + (data.enableEventEnhancement ? '-ee' : '');
 
 if (shouldExitEarly(data, eventData)) {
   return data.gtmOnSuccess();

--- a/template.tpl
+++ b/template.tpl
@@ -1055,7 +1055,7 @@ const toBase64 = require('toBase64');
 
 const eventData = getAllEventData();
 const API_VERSION = '26.0';
-const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.5' + (data.enableEventEnhancement ? '-ee' : '');
+const PARTNER_AGENT_STRING = 'stape-gtmss-2.1.6' + (data.enableEventEnhancement ? '-ee' : '');
 
 if (shouldExitEarly(data, eventData)) {
   return data.gtmOnSuccess();
@@ -3033,7 +3033,7 @@ setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\ncons
   \ 'TraceId', 'Name'];\nconst requiredBqKeys = ['timestamp', 'type', 'trace_id',\
   \ 'tag_name'];\nconst expectedBqOptions = { ignoreUnknownValues: true };\n\nconst\
   \ expectedValue = 'test';\nconst expectedPixelId = '1111111111111';\nconst expectedPartnerAgent\
-  \ = 'stape-gtmss-2.1.5';\nconst expectedApiVersion = '26.0';\n\n\nconst mockData\
+  \ = 'stape-gtmss-2.1.6';\nconst expectedApiVersion = '26.0';\n\n\nconst mockData\
   \ = {\n  pixelId: expectedPixelId,\n  accessToken: expectedValue,\n  inheritEventName:\
   \ 'override',\n  eventNameCustom: expectedValue,\n  logBigQueryProjectId: expectedBigQuerySettings.logBigQueryProjectId,\n\
   \  logBigQueryDatasetId: expectedBigQuerySettings.logBigQueryDatasetId,\n  logBigQueryTableId:\

--- a/template.tpl
+++ b/template.tpl
@@ -1118,19 +1118,11 @@ function getClickAndBrowserId(data, eventData) {
   if (url) {
     const urlParsed = parseUrl(url);
     if (urlParsed && urlParsed.searchParams.fbclid) {
-      if (
-        !ids.fbc ||
-        (ids.fbc &&
-          ids.fbc.split('.')[ids.fbc.split('.').length - 1] !==
-            decodeUriComponent(urlParsed.searchParams.fbclid))
-      ) {
-        ids.fbc =
-          'fb.' +
-          subDomainIndex +
-          '.' +
-          getTimestampMillis() +
-          '.' +
-          decodeUriComponent(urlParsed.searchParams.fbclid);
+      const fbclid = decodeUriComponent(urlParsed.searchParams.fbclid);
+      const fbcParts = ids.fbc ? ids.fbc.split('.') : [];
+
+      if (isValidValue(fbclid) && (!ids.fbc || fbcParts[fbcParts.length - 1] !== fbclid)) {
+        ids.fbc = 'fb.' + subDomainIndex + '.' + getTimestampMillis() + '.' + fbclid;
       }
     }
   }
@@ -1237,12 +1229,16 @@ function mapEvent(data, eventData, fbc, fbp) {
   mappedData = addAppData(data, eventData, mappedData);
   mappedData = addEcommerceData(data, eventData, mappedData);
   mappedData = addOriginalEventData(mappedData);
+
+  if (data.enableEventEnhancement) { // Before cleanup and hashing, so cookie values get both.
+    mappedData.user_data = enhanceEventData(eventData, mappedData.user_data);
+  }
+
   mappedData = overrideDataIfNeeded(mappedData);
   mappedData = cleanupData(mappedData);
   mappedData = hashDataIfNeeded(mappedData);
 
   if (data.enableEventEnhancement) {
-    mappedData.user_data = enhanceEventData(eventData, mappedData.user_data);
     setGtmEecCookie(mappedData.user_data);
   }
 
@@ -1418,8 +1414,6 @@ function addEcommerceData(data, eventData, mappedData) {
     }
 
     if (items) {
-      currencyFromItems = items[0].currency;
-
       mappedData.custom_data.content_type =
         eventData['x-fb-cd-content_type'] || eventData.content_type || 'product';
 
@@ -1436,27 +1430,54 @@ function addEcommerceData(data, eventData, mappedData) {
         if (items[0].item_category)
           mappedData.custom_data.content_category = items[0].item_category;
 
-        if (items[0].price) {
-          mappedData.custom_data.value = items[0].quantity
-            ? items[0].quantity * items[0].price
-            : items[0].price;
+        const singleItemPrice = toFiniteNumber(items[0].price);
+        const singleItemQuantity = toFiniteNumber(items[0].quantity);
+        if (isValidValue(singleItemPrice)) {
+          mappedData.custom_data.value = isValidValue(singleItemQuantity)
+            ? singleItemQuantity * singleItemPrice
+            : singleItemPrice;
         }
       }
 
       const itemIdKey = data.itemIdKey ? data.itemIdKey : 'item_id';
       const mapItemDataTo = data.mapItemDataTo || 'contents';
       items.forEach((d) => {
-        const content = {};
-        if (d[itemIdKey]) content.id = d[itemIdKey];
-        if (d.item_name) content.title = d.item_name;
-        if (d.item_brand) content.brand = d.item_brand;
-        if (d.quantity) content.quantity = d.quantity;
-        if (d.item_category) content.category = d.item_category;
+        if (!currencyFromItems && d.currency) currencyFromItems = d.currency; // Not only items[0].
 
-        if (d.price) {
-          content.item_price = makeNumber(d.price);
-          valueFromItems += d.quantity ? d.quantity * content.item_price : content.item_price;
+        const content = {};
+        let hasContent = false;
+
+        if (isValidValue(d[itemIdKey])) {
+          content.id = makeString(d[itemIdKey]);
+          hasContent = true;
         }
+        if (d.item_name) {
+          content.title = d.item_name;
+          hasContent = true;
+        }
+        if (d.item_brand) {
+          content.brand = d.item_brand;
+          hasContent = true;
+        }
+        if (d.item_category) {
+          content.category = d.item_category;
+          hasContent = true;
+        }
+
+        const quantity = toFiniteNumber(d.quantity);
+        if (isValidValue(quantity)) {
+          content.quantity = quantity;
+          hasContent = true;
+        }
+
+        const itemPrice = toFiniteNumber(d.price);
+        if (isValidValue(itemPrice)) {
+          content.item_price = itemPrice;
+          hasContent = true;
+          valueFromItems += isValidValue(quantity) ? quantity * itemPrice : itemPrice;
+        }
+
+        if (!hasContent) return;
 
         if (mapItemDataTo === 'contents' || mapItemDataTo === 'both') {
           mappedData.custom_data.contents = mappedData.custom_data.contents || [];
@@ -1467,10 +1488,16 @@ function addEcommerceData(data, eventData, mappedData) {
           mappedData.custom_data.content_ids.push(content.id);
         }
       });
+
+      if (!mappedData.custom_data.contents && !mappedData.custom_data.content_ids) {
+        mappedData.custom_data.content_type = undefined; // Nothing left to describe.
+      }
     }
 
-    const value = eventData['x-ga-mp1-ev'] || eventData['x-ga-mp1-tr'] || eventData.value;
-    if (value) mappedData.custom_data.value = value;
+    const value = toFiniteNumber(
+      eventData['x-ga-mp1-ev'] || eventData['x-ga-mp1-tr'] || eventData.value
+    );
+    if (isValidValue(value)) mappedData.custom_data.value = value;
 
     const currency = eventData.currency || currencyFromItems;
     if (currency) mappedData.custom_data.currency = currency;
@@ -1480,9 +1507,15 @@ function addEcommerceData(data, eventData, mappedData) {
     if (eventData.transaction_id) mappedData.custom_data.order_id = eventData.transaction_id;
 
     if (mappedData.event_name === 'Purchase') {
-      if (!mappedData.custom_data.currency) mappedData.custom_data.currency = 'USD';
-      if (!mappedData.custom_data.value)
-        mappedData.custom_data.value = valueFromItems ? valueFromItems : 0;
+      if (!isValidValue(mappedData.custom_data.value))
+        mappedData.custom_data.value = valueFromItems;
+    }
+
+    if (
+      !mappedData.custom_data.currency &&
+      (isValidValue(mappedData.custom_data.value) || valueFromItems)
+    ) {
+      mappedData.custom_data.currency = 'USD'; // A price without a currency is rejected.
     }
   }
 
@@ -1593,6 +1626,7 @@ function addServerEventData(data, eventData, mappedData) {
 
   if (data.serverEventDataList) {
     data.serverEventDataList.forEach((d) => {
+      if (!isValidValue(d.value)) return;
       mappedData[d.name] = d.value;
     });
 
@@ -1727,22 +1761,17 @@ function enhanceEventData(eventData, userData) {
 
   const gtmeecData = JSON.parse(jsonStr);
 
-  if (gtmeecData) {
-    if (!userData.em && gtmeecData.em) userData.em = gtmeecData.em;
-    if (!userData.ph && gtmeecData.ph) userData.ph = gtmeecData.ph;
-    if (!userData.ln && gtmeecData.ln) userData.ln = gtmeecData.ln;
-    if (!userData.fn && gtmeecData.fn) userData.fn = gtmeecData.fn;
-    if (!userData.ct && gtmeecData.ct) userData.ct = gtmeecData.ct;
-    if (!userData.st && gtmeecData.st) userData.st = gtmeecData.st;
-    if (!userData.zp && gtmeecData.zp) userData.zp = gtmeecData.zp;
-    if (!userData.ge && gtmeecData.ge) userData.ge = gtmeecData.ge;
-    if (!userData.db && gtmeecData.db) userData.db = gtmeecData.db;
-    if (!userData.country && gtmeecData.country) userData.country = gtmeecData.country;
-    if (!userData.external_id && gtmeecData.external_id)
-      userData.external_id = gtmeecData.external_id;
-    if (!userData.fb_login_id && gtmeecData.fb_login_id)
-      userData.fb_login_id = gtmeecData.fb_login_id;
+  if (getType(gtmeecData) !== 'object') {
+    return userData;
   }
+
+  const keys = 'em,ph,ln,fn,ct,st,zp,ge,db,country,external_id,fb_login_id'.split(',');
+  keys.forEach((key) => {
+    const value = gtmeecData[key];
+    const valueType = getType(value);
+    if (userData[key] || (valueType !== 'string' && valueType !== 'number')) return;
+    if (isValidValue(value)) userData[key] = value;
+  });
 
   return userData;
 }
@@ -1828,7 +1857,85 @@ function isHashed(value) {
 
 function isValidValue(value) {
   const valueType = getType(value);
-  return valueType !== 'null' && valueType !== 'undefined' && value !== '' && value === value;
+  if (valueType === 'null' || valueType === 'undefined' || value !== value) return false;
+  return value !== '' && value !== 'undefined' && value !== 'null';
+}
+
+function toFiniteNumber(value) {
+  if (!isValidValue(value)) return undefined;
+
+  const valueType = getType(value);
+  if (valueType !== 'number' && valueType !== 'string') return undefined;
+  if (valueType === 'string' && value.trim() === '') return undefined; // Whitespace coerces to 0.
+
+  let parsed = makeNumber(value);
+
+  if (parsed * 0 !== 0 && valueType === 'string') {
+    const recovered = stripCurrencyNotation(value); // '12.50 USD', '$1,234.56'
+    if (!recovered) return undefined;
+    parsed = makeNumber(recovered);
+  }
+
+  if (parsed * 0 !== 0) return undefined; // Rejects NaN and +/-Infinity.
+
+  return parsed;
+}
+
+function stripCurrencyNotation(value) {
+  const raw = makeString(value);
+
+  const shapeRegex = createRegex('^[^0-9,.-]*[0-9][0-9,.]*[^0-9,.-]*$'); // A single digit run.
+  if (!testRegex(shapeRegex, raw)) return '';
+
+  const keepRegex = createRegex('^[0-9,.]$');
+  const core = raw
+    .split('')
+    .filter((item) => testRegex(keepRegex, item))
+    .join('');
+
+  const dots = core.split('.').length - 1;
+  const commas = core.split(',').length - 1;
+
+  let decimal = '';
+  let grouper = '';
+
+  if (dots > 0 && commas > 0) {
+    const dotIsDecimal = core.lastIndexOf('.') > core.lastIndexOf(',');
+    decimal = dotIsDecimal ? '.' : ','; // The rightmost one, under either convention.
+    grouper = dotIsDecimal ? ',' : '.';
+  } else if (commas > 1) {
+    grouper = ','; // A decimal separator appears once, so a repeated one groups.
+  } else if (dots > 1) {
+    grouper = '.';
+  } else if (commas === 1) {
+    if (core.split(',')[1].length === 3) return ''; // Grouping and decimal differ 1000-fold here.
+    decimal = ','; // Grouping is always three digits, so any other width decimalizes.
+  } else if (dots === 1) {
+    decimal = '.';
+  }
+
+  const parts = decimal ? core.split(decimal) : [core];
+  if (parts.length > 2) return '';
+
+  const integer = grouper ? stripGroupSeparators(parts[0], grouper) : parts[0];
+  if (integer === '') return '';
+
+  return parts.length === 2 ? integer + '.' + parts[1] : integer;
+}
+
+function stripGroupSeparators(digits, separator) {
+  const groups = digits.split(separator);
+  const leadRegex = createRegex('^[0-9]{1,3}$');
+  const groupRegex = createRegex('^[0-9]{3}$');
+
+  let valid = testRegex(leadRegex, groups[0]);
+  let position = 0;
+  groups.forEach((group) => {
+    if (position > 0 && !testRegex(groupRegex, group)) valid = false;
+    position++;
+  });
+
+  return valid ? groups.join('') : '';
 }
 
 function normalizePhoneNumber(phoneNumber) {
@@ -2494,6 +2601,47 @@ scenarios:
       assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
       assertThat(requestBody.data[0].action_source).isEqualTo('website');
     });
+- name: '[Server Event Data] An invalid value does not overwrite an auto-mapped field'
+  code: |-
+    mockData.serverEventDataList = [
+      { name: 'event_name', value: undefined },
+      { name: 'action_source', value: 'undefined' }
+    ];
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(expectedValue);
+      assertThat(requestBody.data[0].action_source).isEqualTo('website');
+    });
+- name: '[Event Enhancement] Non-scalar cookie values are ignored'
+  code: |-
+    mockData.enableEventEnhancement = true;
+
+    mock('getCookieValues', (name) => {
+      // {"em": {"a": 1}, "ct": "paris"}
+      if (name === '_gtmeec') return ['eyJlbSI6IHsiYSI6IDF9LCAiY3QiOiAicGFyaXMifQ=='];
+      return [];
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].user_data.em).isUndefined();
+      assertThat(requestBody.data[0].user_data.ct).isDefined();
+    });
 - name: '[Event Name] Explicit inherit with no incoming name is still sent'
   code: |-
     mockData.inheritEventName = 'inherit';
@@ -2653,6 +2801,228 @@ scenarios:
     callLater(() => {
       assertThat(requestBody.data[0].event_name).isEqualTo('ViewContent');
       assertThat(requestBody.data[0].custom_data.content_type).isEqualTo('product_group');
+    });
+- name: '[Event Name] A sentinel override string is not used as the event name'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'custom';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = 'undefined';
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+    });
+- name: '[Currency] Currency is found on an item other than the first'
+  code: |-
+    mock('getAllEventData', {
+      items: [
+        { item_id: 'sku1', price: 5 },
+        { item_id: 'sku2', price: 7, currency: 'EUR' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].custom_data.currency).isEqualTo('EUR');
+    });
+- name: '[Currency] A price with no currency falls back to the existing default'
+  code: |-
+    mock('getAllEventData', {
+      items: [{ item_id: 'sku1', price: '9.99' }]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const customData = requestBody.data[0].custom_data;
+      assertThat(customData.contents[0].id).isEqualTo('sku1');
+      assertThat(customData.contents[0].item_price).isEqualTo(9.99);
+      assertThat(customData.value).isEqualTo(9.99);
+      assertThat(customData.currency).isEqualTo('USD');
+    });
+- name: '[Price] A price carrying its currency notation is recovered'
+  code: |-
+    mock('getAllEventData', {
+      currency: 'EUR',
+      items: [
+        { item_id: 'sku1', price: '12.50 USD', quantity: 2 },
+        { item_id: 'sku2', price: '$4.00' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const contents = requestBody.data[0].custom_data.contents;
+      assertThat(contents[0].item_price).isEqualTo(12.5);
+      assertThat(contents[1].item_price).isEqualTo(4);
+    });
+- name: '[Click ID] A malformed fbclid is not written into the click ID'
+  code: |-
+    mock('getAllEventData', {
+      page_location: 'https://example.com/p?fbclid=%E0%A4%A'
+    });
+    mock('getCookieValues', () => []);
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].user_data.fbc).isEqualTo(undefined);
+    });
+- name: '[Price] A separated price is recovered where the reading is certain'
+  code: |-
+    mock('getAllEventData', {
+      currency: 'EUR',
+      items: [
+        { item_id: 'sku1', price: '1.234,56' },
+        { item_id: 'sku2', price: '1,234.56' },
+        { item_id: 'sku3', price: '12,50' },
+        { item_id: 'sku4', price: '1,234,567' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const contents = requestBody.data[0].custom_data.contents;
+      assertThat(contents[0].item_price).isEqualTo(1234.56);
+      assertThat(contents[1].item_price).isEqualTo(1234.56);
+      assertThat(contents[2].item_price).isEqualTo(12.5);
+      assertThat(contents[3].item_price).isEqualTo(1234567);
+    });
+- name: '[Price] A comma that could group or decimalize is dropped'
+  code: |-
+    mock('getAllEventData', {
+      currency: 'EUR',
+      items: [
+        { item_id: 'sku1', price: '1,234' },
+        { item_id: 'sku2', price: '0,500' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const contents = requestBody.data[0].custom_data.contents;
+      assertThat(contents[0].item_price).isEqualTo(undefined);
+      assertThat(contents[1].item_price).isEqualTo(undefined);
+    });
+- name: '[Price] A blank price does not become a zero-value event'
+  code: |-
+    mock('getAllEventData', {
+      event_name: 'purchase',
+      items: [{ item_id: 'sku1', price: ' ' }]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const customData = requestBody.data[0].custom_data;
+      assertThat(customData.contents[0].item_price).isEqualTo(undefined);
+      assertThat(customData.value).isEqualTo(undefined);
+      assertThat(customData.currency).isEqualTo(undefined);
+    });
+- name: '[Contents] Mapping item data to content_ids only does not require contents'
+  code: |-
+    mock('getAllEventData', {
+      currency: 'USD',
+      items: [
+        { item_id: 'sku1', price: '12.50 USD' },
+        { item_name: 'no id or price' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mergeObj({ mapItemDataTo: 'content_ids' }, mockData));
+
+    callLater(() => {
+      const customData = requestBody.data[0].custom_data;
+      assertThat(customData.content_ids).isEqualTo(['sku1']);
+      assertThat(customData.contents).isEqualTo(undefined);
+      assertThat(customData.content_type).isEqualTo('product');
+    });
+- name: '[Price] A malformed price is still rejected'
+  code: |-
+    mock('getAllEventData', {
+      currency: 'EUR',
+      items: [
+        { item_id: 'sku1', price: '1.2.3' },
+        { item_id: 'sku2', price: '3 x 12.50' },
+        { item_id: 'sku3', price: '1,23,456' }
+      ]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      const contents = requestBody.data[0].custom_data.contents;
+      assertThat(contents[0].item_price).isEqualTo(undefined);
+      assertThat(contents[1].item_price).isEqualTo(undefined);
+      assertThat(contents[2].item_price).isEqualTo(undefined);
     });
 setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\nconst\
   \ callLater = require('callLater');\n\nconst mergeObj = (target, source) => {\n\

--- a/template.tpl
+++ b/template.tpl
@@ -55,6 +55,7 @@ ___TEMPLATE_PARAMETERS___
           }
         ],
         "simpleValueType": true,
+        "defaultValue": "inherit",
         "subParams": [
           {
             "type": "RADIO",
@@ -146,7 +147,12 @@ ___TEMPLATE_PARAMETERS___
                         "displayValue": "ViewContent"
                       }
                     ],
-                    "simpleValueType": true
+                    "simpleValueType": true,
+                    "valueValidators": [
+                      {
+                        "type": "NON_EMPTY"
+                      }
+                    ]
                   }
                 ]
               },
@@ -157,12 +163,18 @@ ___TEMPLATE_PARAMETERS___
                   {
                     "type": "TEXT",
                     "name": "eventNameCustom",
-                    "simpleValueType": true
+                    "simpleValueType": true,
+                    "valueValidators": [
+                      {
+                        "type": "NON_EMPTY"
+                      }
+                    ]
                   }
                 ]
               }
             ],
             "simpleValueType": true,
+            "defaultValue": "standard",
             "enablingConditions": [
               {
                 "paramName": "inheritEventName",
@@ -1137,46 +1149,60 @@ function getClickAndBrowserId(data, eventData) {
 }
 
 function getEventName(data) {
-  if (data.inheritEventName === 'inherit') {
+  const gaToFacebookEventName = {
+    page_view: 'PageView',
+    'gtm.dom': 'PageView',
+    add_payment_info: 'AddPaymentInfo',
+    add_to_cart: 'AddToCart',
+    add_to_wishlist: 'AddToWishlist',
+    sign_up: 'CompleteRegistration',
+    begin_checkout: 'InitiateCheckout',
+    generate_lead: 'Lead',
+    purchase: 'Purchase',
+    search: 'Search',
+    view_item: 'ViewContent',
+
+    contact: 'Contact',
+    customize_product: 'CustomizeProduct',
+    donate: 'Donate',
+    find_location: 'FindLocation',
+    schedule: 'Schedule',
+    start_trial: 'StartTrial',
+    submit_application: 'SubmitApplication',
+    subscribe: 'Subscribe',
+
+    'gtm4wp.addProductToCartEEC': 'AddToCart',
+    'gtm4wp.productClickEEC': 'ViewContent',
+    'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
+    'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
+    'gtm4wp.orderCompletedEEC': 'Purchase'
+  };
+
+  if (data.mapViewItemListToViewContent) {
+    gaToFacebookEventName.view_item_list = 'ViewContent';
+  }
+
+  if (data.inheritEventName !== 'override') { // An absent setting inherits.
     const eventName = eventData.event_name;
-
-    const gaToFacebookEventName = {
-      page_view: 'PageView',
-      'gtm.dom': 'PageView',
-      add_payment_info: 'AddPaymentInfo',
-      add_to_cart: 'AddToCart',
-      add_to_wishlist: 'AddToWishlist',
-      sign_up: 'CompleteRegistration',
-      begin_checkout: 'InitiateCheckout',
-      generate_lead: 'Lead',
-      purchase: 'Purchase',
-      search: 'Search',
-      view_item: 'ViewContent',
-
-      contact: 'Contact',
-      customize_product: 'CustomizeProduct',
-      donate: 'Donate',
-      find_location: 'FindLocation',
-      schedule: 'Schedule',
-      start_trial: 'StartTrial',
-      submit_application: 'SubmitApplication',
-      subscribe: 'Subscribe',
-
-      'gtm4wp.addProductToCartEEC': 'AddToCart',
-      'gtm4wp.productClickEEC': 'ViewContent',
-      'gtm4wp.checkoutOptionEEC': 'InitiateCheckout',
-      'gtm4wp.checkoutStepEEC': 'AddPaymentInfo',
-      'gtm4wp.orderCompletedEEC': 'Purchase'
-    };
-
-    if (data.mapViewItemListToViewContent) {
-      gaToFacebookEventName.view_item_list = 'ViewContent';
-    }
-
     return gaToFacebookEventName[eventName] || eventName;
   }
 
-  return data.eventName === 'standard' ? data.eventNameStandard : data.eventNameCustom;
+  const selected =
+    data.eventName === 'standard'
+      ? data.eventNameStandard
+      : data.eventName === 'custom'
+        ? data.eventNameCustom
+        : undefined;
+
+  if (isValidValue(selected)) return selected;
+
+  if (['standard', 'custom'].indexOf(data.eventName) === -1) { // Radio unset but a name saved.
+    const configured = data.eventNameStandard || data.eventNameCustom;
+    if (isValidValue(configured)) return configured;
+  }
+
+  // An incomplete override falls back to the incoming name, as the inherit branch does.
+  return gaToFacebookEventName[eventData.event_name] || eventData.event_name;
 }
 
 function mapEvent(data, eventData, fbc, fbp) {
@@ -1399,7 +1425,7 @@ function addEcommerceData(data, eventData, mappedData) {
 
       if (
         data.mapViewItemListToViewContent &&
-        data.inheritEventName === 'inherit' &&
+        data.inheritEventName !== 'override' &&
         eventData.event_name === 'view_item_list'
       ) {
         mappedData.custom_data.content_type = 'product_group';
@@ -1831,7 +1857,6 @@ function isConsentGivenOrNotRequired(data, eventData) {
   const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
   return xGaGcs[2] === '1';
 }
-
 
 ___SERVER_PERMISSIONS___
 
@@ -2432,6 +2457,203 @@ scenarios:
     \ reject) => reject({ reason: 'failed' }))\n});\n\nrunCode(mockData);\n\ncallLater(()\
     \ => {\n  assertApi('gtmOnSuccess').wasNotCalled();\n  assertApi('gtmOnFailure').wasCalled();\n\
     });"
+- name: '[Event Name] Inherited from the client when the setup method is not set'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] An unresolvable event name is sent without one, not invented'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+      assertThat(requestBody.data[0].action_source).isEqualTo('website');
+    });
+- name: '[Event Name] Explicit inherit with no incoming name is still sent'
+  code: |-
+    mockData.inheritEventName = 'inherit';
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+    });
+- name: '[Event Name] Override with no standard event selected falls back to a mapped name'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] Override with a blank custom name falls back to a mapped name'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'custom';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = '';
+
+    mock('getAllEventData', { event_name: 'add_to_cart' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('AddToCart');
+    });
+- name: '[Event Name] Incomplete override forwards an unmapped incoming name as-is'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    // Not in the GA4 mapping table, so it is forwarded unchanged as a custom event.
+    mock('getAllEventData', { event_name: 'session_start' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('session_start');
+    });
+- name: '[Event Name] Incomplete override with no incoming name is still sent'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = undefined;
+    mockData.eventNameCustom = undefined;
+
+    mock('getAllEventData', {});
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo(undefined);
+    });
+- name: '[Event Name] Override with a selected standard event is sent as chosen'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'standard';
+    mockData.eventNameStandard = 'PageView';
+    mockData.eventNameCustom = undefined;
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('PageView');
+    });
+- name: '[Event Name] A deselected standard event is not reused as a custom override'
+  code: |-
+    mockData.inheritEventName = 'override';
+    mockData.eventName = 'custom';
+    mockData.eventNameStandard = 'PageView';
+    mockData.eventNameCustom = '';
+
+    mock('getAllEventData', { event_name: 'purchase' });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('Purchase');
+    });
+- name: '[Event Name] An absent inherit setting still maps view_item_list to a product group'
+  code: |-
+    mockData.inheritEventName = undefined;
+    mockData.eventNameCustom = undefined;
+    mockData.mapViewItemListToViewContent = true;
+
+    mock('getAllEventData', {
+      event_name: 'view_item_list',
+      items: [{ item_id: 'SKU_1' }, { item_id: 'SKU_2' }]
+    });
+
+    let requestBody;
+    mock('sendHttpRequest', (requestUrl, requestOptions, body) => {
+      requestBody = JSON.parse(body);
+      return Promise.create((resolve) => resolve({ statusCode: 200 }));
+    });
+
+    runCode(mockData);
+
+    callLater(() => {
+      assertThat(requestBody.data[0].event_name).isEqualTo('ViewContent');
+      assertThat(requestBody.data[0].custom_data.content_type).isEqualTo('product_group');
+    });
 setup: "const JSON = require('JSON');\nconst Promise = require('Promise');\nconst\
   \ callLater = require('callLater');\n\nconst mergeObj = (target, source) => {\n\
   \  for (const key in source) {\n    if (source.hasOwnProperty(key)) target[key]\


### PR DESCRIPTION
Stacks on #96 and #97 — the first two commits here are those PRs. Base is `main`
only because a cross-fork PR cannot target a branch that does not exist upstream;
review the third commit for the change below.

## What this changes

Bumps `PARTNER_AGENT_STRING` from `stape-gtmss-2.1.5` to `stape-gtmss-2.1.6`, so the behaviour changes in the preceding two PRs are distinguishable from the 2.1.5 release on the receiving end.

Kept separate from the fixes so the version can be taken, deferred, or replaced with your own numbering independently of them.

## Tests

`expectedPartnerAgent` in the `___TESTS___` setup is updated to match — three existing scenarios assert the full request body and fail otherwise. The dated `___NOTES___` entry referencing 2.1.4 is left alone as a historical record.

All 33 scenarios pass.
